### PR TITLE
Fix shop action parsing and format issues

### DIFF
--- a/game.go
+++ b/game.go
@@ -767,7 +767,7 @@ func (g *Game) showShopWithItems(availableJokers []Joker, shopItems []Joker) {
 		} else {
 			g.eventEmitter.EmitEvent(InvalidActionEvent{
 				Action: "unknown",
-				Reason: fmt.Sprintf("Invalid action (given '%d'). Use 'buy <number>', 'reroll', or 'exit'.", action),
+				Reason: fmt.Sprintf("Invalid action (given '%s'). Use 'buy <number>', 'reroll', or 'exit'.", action),
 			})
 		}
 	}

--- a/logger_event_handler.go
+++ b/logger_event_handler.go
@@ -93,7 +93,7 @@ func (h *LoggerEventHandler) handleCardsDealt(e CardsDealtEvent) {
 			fmt.Println()
 		}
 	}
-	fmt.Println("\n")
+	fmt.Println()
 }
 
 func (h *LoggerEventHandler) handleHandPlayed(e HandPlayedEvent) {
@@ -368,24 +368,23 @@ func (h *LoggerEventHandler) GetShopAction() (PlayerAction, []string, bool) {
 		return PlayerActionExitShop, nil, false
 	}
 
-	parts := strings.Split(input, "")
-	params := make([]string, 0)
-	for _, part := range parts[1:] {
-		if strings.TrimSpace(part) != "" {
-			params = append(params, part)
-		}
+	parts := strings.Fields(input)
+	var params []string
+	if len(parts) > 1 {
+		params = parts[1:]
 	}
+
 	var action PlayerAction
 	switch strings.ToLower(parts[0]) {
-	case "b":
+	case "b", "buy":
 		action = PlayerActionBuy
-	case "r":
+	case "r", "reroll":
 		action = PlayerActionReroll
 	default:
 		fmt.Println("No action recognized", input)
 		action = PlayerActionNone
 	}
-	// convert the option
+
 	return action, params, false
 }
 

--- a/logger_event_handler_test.go
+++ b/logger_event_handler_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
+	handler := &LoggerEventHandler{scanner: bufio.NewScanner(strings.NewReader("buy 12\n"))}
+	action, params, quit := handler.GetShopAction()
+	if quit {
+		t.Fatalf("expected quit to be false, got true")
+	}
+	if action != PlayerActionBuy {
+		t.Fatalf("expected action %s, got %s", PlayerActionBuy, action)
+	}
+	if len(params) != 1 || params[0] != "12" {
+		t.Fatalf("expected params [\"12\"], got %v", params)
+	}
+}
+
+func TestGetShopActionParsesReroll(t *testing.T) {
+	handler := &LoggerEventHandler{scanner: bufio.NewScanner(strings.NewReader("reroll\n"))}
+	action, params, quit := handler.GetShopAction()
+	if quit {
+		t.Fatalf("expected quit to be false, got true")
+	}
+	if action != PlayerActionReroll {
+		t.Fatalf("expected action %s, got %s", PlayerActionReroll, action)
+	}
+	if len(params) != 0 {
+		t.Fatalf("expected no params, got %v", params)
+	}
+}


### PR DESCRIPTION
## Summary
- Correctly parse shop commands and their parameters in the logger event handler
- Fix invalid format string for unknown actions
- Avoid redundant newline when displaying dealt cards
- Add tests for logger shop actions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68993f63d3d8832c84022200a5d9020e