### PR TITLE
Implement TUI shop reroll action

### DIFF
--- a/game.go
+++ b/game.go
@@ -554,7 +554,7 @@ func (g *Game) showShop() {
 			if g.money >= g.rerollCost {
 				oldCost := g.rerollCost
 				g.money -= g.rerollCost
-				g.rerollCost++
+				g.rerollCost += 2
 
 				// Generate new shop items
 				if len(availableJokers) >= 2 {
@@ -682,7 +682,7 @@ func (g *Game) showShopWithItems(availableJokers []Joker, shopItems []Joker) {
 			if g.money >= g.rerollCost {
 				oldCost := g.rerollCost
 				g.money -= g.rerollCost
-				g.rerollCost++
+				g.rerollCost += 2
 
 				// Generate new shop items
 				if len(availableJokers) >= 2 {
@@ -767,7 +767,7 @@ func (g *Game) showShopWithItems(availableJokers []Joker, shopItems []Joker) {
 		} else {
 			g.eventEmitter.EmitEvent(InvalidActionEvent{
 				Action: "unknown",
-				Reason: fmt.Sprintf("Invalid action (given '%d'). Use 'buy <number>', 'reroll', or 'exit'.", action),
+				Reason: fmt.Sprintf("Invalid action (given '%s'). Use 'buy <number>', 'reroll', or 'exit'.", action),
 			})
 		}
 	}

--- a/logger_event_handler.go
+++ b/logger_event_handler.go
@@ -93,7 +93,7 @@ func (h *LoggerEventHandler) handleCardsDealt(e CardsDealtEvent) {
 			fmt.Println()
 		}
 	}
-	fmt.Println("\n")
+	fmt.Println()
 }
 
 func (h *LoggerEventHandler) handleHandPlayed(e HandPlayedEvent) {

--- a/shop_test.go
+++ b/shop_test.go
@@ -138,23 +138,23 @@ func TestRerollCostProgression(t *testing.T) {
 	// Simulate reroll
 	if game.money >= game.rerollCost {
 		game.money -= game.rerollCost
-		game.rerollCost++
+		game.rerollCost += 2
 	}
 
-	// After first reroll, cost should be 6
-	if game.rerollCost != 6 {
-		t.Errorf("Expected reroll cost to be 6 after first reroll, got %d", game.rerollCost)
+	// After first reroll, cost should be 7
+	if game.rerollCost != 7 {
+		t.Errorf("Expected reroll cost to be 7 after first reroll, got %d", game.rerollCost)
 	}
 
 	// Simulate another reroll
 	if game.money >= game.rerollCost {
 		game.money -= game.rerollCost
-		game.rerollCost++
+		game.rerollCost += 2
 	}
 
-	// After second reroll, cost should be 7
-	if game.rerollCost != 7 {
-		t.Errorf("Expected reroll cost to be 7 after second reroll, got %d", game.rerollCost)
+	// After second reroll, cost should be 9
+	if game.rerollCost != 9 {
+		t.Errorf("Expected reroll cost to be 9 after second reroll, got %d", game.rerollCost)
 	}
 }
 

--- a/tui.go
+++ b/tui.go
@@ -240,6 +240,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		event := ShopOpenedEvent(msg)
 		shopCopy := event
 		m.shopInfo = &shopCopy
+		m.gameState.Money = event.Money
 		m.mode = ShoppingMode{}
 		m.setStatusMessage("🛍️ Welcome to the Shop!")
 		return m, nil
@@ -247,12 +248,18 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case shopItemPurchasedMsg:
 		m.lastActivity = time.Now() // User purchased item
 		event := ShopItemPurchasedEvent(msg)
+		m.gameState.Money = event.RemainingMoney
 		m.setStatusMessage(fmt.Sprintf("✨ Purchased %s! Remaining: $%d", event.Item.Name, event.RemainingMoney))
 		return m, nil
 
 	case shopRerolledMsg:
 		m.lastActivity = time.Now() // User rerolled shop
 		event := ShopRerolledEvent(msg)
+		m.gameState.Money = event.RemainingMoney
+		if m.shopInfo != nil {
+			m.shopInfo.RerollCost = event.NewRerollCost
+			m.shopInfo.Items = event.NewItems
+		}
 		m.setStatusMessage(fmt.Sprintf("💫 Shop rerolled for $%d! Next reroll: $%d", event.Cost, event.NewRerollCost))
 		return m, nil
 

--- a/tui_shop.go
+++ b/tui_shop.go
@@ -12,8 +12,8 @@ type ShoppingMode struct{}
 
 func (ms ShoppingMode) renderContent(m TUIModel) string {
 	gameInfo := fmt.Sprintf("%s Ante %d - %s✅\n", "🏪", m.gameState.Ante, m.gameState.Blind) +
-		fmt.Sprintf("🎴 Hands: %d | 🗑️ Discards: %d | 💰 Money: $%d",
-			m.gameState.Hands, m.gameState.Discards, m.gameState.Money)
+		fmt.Sprintf("🎴 Hands: %d | 🗑️ Discards: %d | 💰 Money: $%d | 🎲 Reroll: $%d",
+			m.gameState.Hands, m.gameState.Discards, m.gameState.Money, m.shopInfo.RerollCost)
 	gameInfoBox := gameInfoStyle.
 		Height(5).
 		Render(gameInfo)


### PR DESCRIPTION
## Summary
- Increase shop reroll cost by $2 each time and deduct funds accordingly
- Refresh TUI shop state after reroll, including money, reroll cost and new joker items
- Display current reroll cost in the shop and update tests for new pricing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68993fea2860832ca6ae7d29ddcc5d28