### PR TITLE
Fix exiting help mode via Escape or Enter

### DIFF
--- a/tui_game.go
+++ b/tui_game.go
@@ -242,8 +242,9 @@ func (gm GameHelpMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.C
 	m.lastActivity = time.Now()
 	// fmt.Println(msg)
 	m.setStatusMessage(msg)
-	if msg == "esc" || msg == "h" || msg == "enter" {
-		gm.toggleHelp()
+	if msg == "esc" || msg == "escape" || msg == "enter" {
+		m.showHelp = !m.showHelp
+		m.mode = gm.toggleHelp()
 	}
 
 	return m, nil

--- a/tui_shop.go
+++ b/tui_shop.go
@@ -177,9 +177,9 @@ func (gm ShopHelpMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.C
 	m.lastActivity = time.Now()
 	// fmt.Println(msg)
 	m.setStatusMessage(msg)
-	if msg == "esc" || msg == "h" || msg == "enter" {
+	if msg == "esc" || msg == "escape" || msg == "enter" {
 		m.showHelp = !m.showHelp
-		gm.toggleHelp()
+		m.mode = gm.toggleHelp()
 	}
 
 	return m, nil


### PR DESCRIPTION
## Summary
- Allow closing game help with Enter or Escape keys
- Allow closing shop help with Enter or Escape keys

## Testing
- `go test ./...` *(fails: fmt.Sprintf format %d has arg action of wrong type balatno.PlayerAction)*

------
https://chatgpt.com/codex/tasks/task_e_68994142c23c832ca65c533a7d5e9e0f