### PR TITLE
docs: clarify handleResortAction comment

### DIFF
--- a/game.go
+++ b/game.go
@@ -766,8 +766,7 @@ func removeCards(cards []Card, indices []int) []Card {
 	return result
 }
 
-// handleResortAction toggles the sort mode and redisplays cards
-// handleResortAction handles resorting cards
+// handleResortAction toggles the card sort mode and updates the display mapping
 func (g *Game) handleResortAction() {
 	if g.sortMode == SortByRank {
 		g.sortMode = SortBySuit


### PR DESCRIPTION
## Summary
- remove redundant handleResortAction comment
- clarify remaining comment to describe resort action behavior

## Testing
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_689942e6741c832ca11f73730ff13ac5