### PR TITLE
Handle duplicate card selections

### DIFF
--- a/game.go
+++ b/game.go
@@ -348,6 +348,7 @@ func (g *Game) handleDiscardAction(params []string) {
 func (g *Game) parseCardSelection(params []string) ([]Card, []int, bool) {
 	var selectedCards []Card
 	var selectedIndices []int
+	seen := make(map[int]bool)
 
 	for _, param := range params {
 		displayIndex, err := strconv.Atoi(param)
@@ -358,6 +359,13 @@ func (g *Game) parseCardSelection(params []string) ([]Card, []int, bool) {
 			})
 			return nil, nil, false
 		}
+
+		if seen[displayIndex] {
+			g.eventEmitter.EmitWarning(fmt.Sprintf("Duplicate card number: %d ignored", displayIndex))
+			continue
+		}
+		seen[displayIndex] = true
+
 		// Since playerCards is already sorted by updateDisplayToOriginalMapping,
 		// display position directly corresponds to current array position
 		arrayIndex := displayIndex - 1 // Convert 1-based to 0-based


### PR DESCRIPTION
## Summary
- Track seen display indices when parsing card selections
- Warn and skip duplicate card numbers during selection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689942eead7c832c849eb09cab2b6e15