### PR TITLE
Add tests for core game mechanics and TUI flows

### DIFF
--- a/internal/game/deck_shuffle_test.go
+++ b/internal/game/deck_shuffle_test.go
@@ -1,0 +1,21 @@
+package game
+
+import "testing"
+
+// TestShuffleDeckDeterministic ensures that shuffling with the same seed
+// produces the same card order.
+func TestShuffleDeckDeterministic(t *testing.T) {
+	SetSeed(99)
+	d1 := NewDeck()
+	ShuffleDeck(d1)
+
+	SetSeed(99)
+	d2 := NewDeck()
+	ShuffleDeck(d2)
+
+	for i := range d1 {
+		if d1[i] != d2[i] {
+			t.Fatalf("expected deterministic shuffle, card %d differs", i)
+		}
+	}
+}

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -1,0 +1,151 @@
+package game
+
+import "testing"
+
+// testEventHandler is a minimal EventHandler implementation for testing.
+type testEventHandler struct {
+	events      []Event
+	shopActions []struct {
+		action PlayerAction
+		params []string
+	}
+	actionIdx int
+}
+
+func (t *testEventHandler) HandleEvent(e Event) {
+	t.events = append(t.events, e)
+}
+
+func (t *testEventHandler) GetPlayerAction(bool) (PlayerAction, []string, bool) {
+	return PlayerActionNone, nil, false
+}
+
+func (t *testEventHandler) GetShopAction() (PlayerAction, []string, bool) {
+	if t.actionIdx >= len(t.shopActions) {
+		return PlayerActionExitShop, nil, false
+	}
+	a := t.shopActions[t.actionIdx]
+	t.actionIdx++
+	return a.action, a.params, false
+}
+
+func (t *testEventHandler) Close() {}
+
+// TestHandlePlayAction verifies that playing cards updates score, hand count
+// and emits a HandPlayedEvent.
+func TestHandlePlayAction(t *testing.T) {
+	handler := &testEventHandler{}
+	deck := NewDeck()
+	g := &Game{
+		deck:         deck,
+		deckIndex:    7,
+		playerCards:  []Card{{Rank: Ten, Suit: Hearts}, {Rank: Ten, Suit: Clubs}, {Rank: Three, Suit: Diamonds}, {Rank: Four, Suit: Spades}, {Rank: Five, Suit: Hearts}, {Rank: Six, Suit: Clubs}, {Rank: Seven, Suit: Diamonds}},
+		eventEmitter: NewEventEmitter(),
+	}
+	g.eventEmitter.SetEventHandler(handler)
+
+	g.handlePlayAction([]string{"1", "2"})
+
+	if g.handsPlayed != 1 {
+		t.Fatalf("expected hands played to be 1, got %d", g.handsPlayed)
+	}
+	if g.totalScore <= 0 {
+		t.Fatalf("expected positive score, got %d", g.totalScore)
+	}
+	if len(g.playerCards) != 7 {
+		t.Fatalf("expected 7 cards after playing, got %d", len(g.playerCards))
+	}
+
+	found := false
+	for _, e := range handler.events {
+		if _, ok := e.(HandPlayedEvent); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected HandPlayedEvent to be emitted")
+	}
+}
+
+// TestHandleDiscardAction verifies discarding cards updates discard count and
+// emits a CardsDiscardedEvent.
+func TestHandleDiscardAction(t *testing.T) {
+	handler := &testEventHandler{}
+	deck := NewDeck()
+	g := &Game{
+		deck:         deck,
+		deckIndex:    7,
+		playerCards:  deck[:7],
+		eventEmitter: NewEventEmitter(),
+	}
+	g.eventEmitter.SetEventHandler(handler)
+
+	g.handleDiscardAction([]string{"1", "2"})
+
+	if g.discardsUsed != 1 {
+		t.Fatalf("expected 1 discard used, got %d", g.discardsUsed)
+	}
+	if len(g.playerCards) != 7 {
+		t.Fatalf("expected 7 cards after discard, got %d", len(g.playerCards))
+	}
+	found := false
+	for _, e := range handler.events {
+		if _, ok := e.(CardsDiscardedEvent); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected CardsDiscardedEvent to be emitted")
+	}
+}
+
+// TestShowShopWithItems ensures that purchasing an item deducts money, adds the
+// joker and emits the appropriate events.
+func TestShowShopWithItems(t *testing.T) {
+	handler := &testEventHandler{
+		shopActions: []struct {
+			action PlayerAction
+			params []string
+		}{
+			{PlayerActionBuy, []string{"1"}},
+			{PlayerActionExitShop, nil},
+		},
+	}
+
+	g := &Game{
+		money:        10,
+		rerollCost:   5,
+		jokers:       []Joker{},
+		eventEmitter: NewEventEmitter(),
+	}
+	g.eventEmitter.SetEventHandler(handler)
+
+	available := []Joker{{Name: "J1", Price: 5, Description: ""}, {Name: "J2", Price: 6, Description: ""}}
+	shop := []Joker{available[0], available[1]}
+
+	g.showShopWithItems(available, shop)
+
+	if g.money != 5 {
+		t.Fatalf("expected money to be 5 after purchase, got %d", g.money)
+	}
+	if len(g.jokers) != 1 || g.jokers[0].Name != "J1" {
+		t.Fatalf("expected to own J1 after purchase")
+	}
+	opened, purchased := false, false
+	for _, e := range handler.events {
+		switch e.(type) {
+		case ShopOpenedEvent:
+			opened = true
+		case ShopItemPurchasedEvent:
+			purchased = true
+		}
+	}
+	if !opened {
+		t.Fatalf("expected ShopOpenedEvent to be emitted")
+	}
+	if !purchased {
+		t.Fatalf("expected ShopItemPurchasedEvent to be emitted")
+	}
+}

--- a/internal/game/jokers_test.go
+++ b/internal/game/jokers_test.go
@@ -1,0 +1,36 @@
+package game
+
+import "testing"
+
+// TestCalculateJokerRewards verifies AddMoney joker rewards at blind end.
+func TestCalculateJokerRewards(t *testing.T) {
+	j := Joker{OnBlindEnd: func() int { return 4 }}
+	if got := CalculateJokerRewards([]Joker{j}); got != 4 {
+		t.Fatalf("expected 4, got %d", got)
+	}
+}
+
+// TestCalculateJokerHandBonus verifies chip and multiplier bonuses from jokers.
+func TestCalculateJokerHandBonus(t *testing.T) {
+	chipCfg := JokerConfig{Name: "Chip", Effect: AddChips, EffectMagnitude: 30, HandMatchingRule: ContainsPair}
+	chipJoker := createJokerFromConfig(chipCfg)
+
+	multCfg := JokerConfig{Name: "Mult", Effect: AddMult, EffectMagnitude: 5, HandMatchingRule: ContainsPair}
+	multJoker := createJokerFromConfig(multCfg)
+
+	chips, mult := CalculateJokerHandBonus([]Joker{chipJoker}, "Pair")
+	if chips != 30 || mult != 0 {
+		t.Fatalf("expected 30 chips bonus, got chips=%d mult=%d", chips, mult)
+	}
+
+	chips, mult = CalculateJokerHandBonus([]Joker{multJoker}, "Pair")
+	if chips != 0 || mult != 5 {
+		t.Fatalf("expected mult bonus 5, got chips=%d mult=%d", chips, mult)
+	}
+
+	// Non-matching hand should yield no bonus
+	chips, mult = CalculateJokerHandBonus([]Joker{chipJoker}, "High Card")
+	if chips != 0 || mult != 0 {
+		t.Fatalf("expected no bonus for non-matching hand, got chips=%d mult=%d", chips, mult)
+	}
+}

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	game "balatno/internal/game"
+)
+
+// TestToggleCardSelection verifies selecting and deselecting cards.
+func TestToggleCardSelection(t *testing.T) {
+	m := TUIModel{cards: []game.Card{{Rank: game.Ace, Suit: game.Spades}}}
+
+	if m.isCardSelected(0) {
+		t.Fatalf("card should not be selected initially")
+	}
+
+	m.toggleCardSelection(0)
+	if !m.isCardSelected(0) {
+		t.Fatalf("card should be selected after toggle")
+	}
+
+	m.toggleCardSelection(0)
+	if m.isCardSelected(0) {
+		t.Fatalf("card should be deselected after second toggle")
+	}
+}
+
+// TestHelpToggle ensures that pressing 'h' toggles help mode on and off.
+func TestHelpToggle(t *testing.T) {
+	m := TUIModel{mode: GameMode{}}
+
+	model, _ := m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	m = model.(TUIModel)
+
+	if !m.showHelp {
+		t.Fatalf("expected help to be shown")
+	}
+	if _, ok := m.mode.(*GameHelpMode); !ok {
+		t.Fatalf("expected mode to be GameHelpMode")
+	}
+
+	model, _ = m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	m = model.(TUIModel)
+
+	if m.showHelp {
+		t.Fatalf("expected help to be hidden")
+	}
+	if _, ok := m.mode.(*GameMode); !ok {
+		t.Fatalf("expected mode to be GameMode after toggling back")
+	}
+}
+
+// TestShoppingModeActions verifies purchase and reroll flows in the shop.
+func TestShoppingModeActions(t *testing.T) {
+	// Prepare a model with one affordable item and a pending request
+	respChan := make(chan PlayerActionResponse, 1)
+	selected := 0
+	m := TUIModel{
+		gameState:            game.GameStateChangedEvent{Money: 10},
+		shopInfo:             &game.ShopOpenedEvent{Money: 10, RerollCost: 5, Items: []game.ShopItemData{{Name: "J1", Cost: 5, Description: "", CanAfford: true}}},
+		mode:                 ShoppingMode{selectedItem: &selected},
+		actionRequestPending: &PlayerActionRequest{ResponseChan: respChan},
+	}
+
+	// Purchasing selected item
+	model, _ := m.handleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	resp := <-respChan
+	if resp.Action != game.PlayerActionBuy || len(resp.Params) != 1 || resp.Params[0] != "0" {
+		t.Fatalf("unexpected purchase response: %+v", resp)
+	}
+
+	// Reroll action
+	respChan = make(chan PlayerActionResponse, 1)
+	mPtr := model.(*TUIModel)
+	m = *mPtr
+	m.actionRequestPending = &PlayerActionRequest{ResponseChan: respChan}
+	m.mode = ShoppingMode{}
+	model, _ = m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	resp = <-respChan
+	if resp.Action != game.PlayerActionReroll {
+		t.Fatalf("unexpected reroll response: %+v", resp)
+	}
+}

--- a/logger_event_handler_test.go
+++ b/logger_event_handler_test.go
@@ -2,18 +2,33 @@ package main
 
 import (
 	"bufio"
+	"reflect"
 	"strings"
 	"testing"
+	"unsafe"
+
+	game "balatno/internal/game"
 )
 
+// newHandlerWithInput creates a LoggerEventHandler with a custom input scanner.
+// The LoggerEventHandler's scanner field is unexported, so reflection is used to
+// inject our own scanner for testing.
+func newHandlerWithInput(input string) *game.LoggerEventHandler {
+	h := game.NewLoggerEventHandler()
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	v := reflect.ValueOf(h).Elem().FieldByName("scanner")
+	reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().Set(reflect.ValueOf(scanner))
+	return h
+}
+
 func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
-	handler := &LoggerEventHandler{scanner: bufio.NewScanner(strings.NewReader("buy 12\n"))}
+	handler := newHandlerWithInput("buy 12\n")
 	action, params, quit := handler.GetShopAction()
 	if quit {
 		t.Fatalf("expected quit to be false, got true")
 	}
-	if action != PlayerActionBuy {
-		t.Fatalf("expected action %s, got %s", PlayerActionBuy, action)
+	if action != game.PlayerActionBuy {
+		t.Fatalf("expected action %s, got %s", game.PlayerActionBuy, action)
 	}
 	if len(params) != 1 || params[0] != "12" {
 		t.Fatalf("expected params [\"12\"], got %v", params)
@@ -21,13 +36,13 @@ func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
 }
 
 func TestGetShopActionParsesReroll(t *testing.T) {
-	handler := &LoggerEventHandler{scanner: bufio.NewScanner(strings.NewReader("reroll\n"))}
+	handler := newHandlerWithInput("reroll\n")
 	action, params, quit := handler.GetShopAction()
 	if quit {
 		t.Fatalf("expected quit to be false, got true")
 	}
-	if action != PlayerActionReroll {
-		t.Fatalf("expected action %s, got %s", PlayerActionReroll, action)
+	if action != game.PlayerActionReroll {
+		t.Fatalf("expected action %s, got %s", game.PlayerActionReroll, action)
 	}
 	if len(params) != 0 {
 		t.Fatalf("expected no params, got %v", params)


### PR DESCRIPTION
## Summary
- Add unit tests for play, discard, and shop flows in the game
- Introduce TUI tests for card selection, help toggle, and shop actions
- Cover deck shuffling determinism and joker effect calculations

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68994a003f0c832ca3e9361a8a195671