### PR TITLE
Use pointer-based modes in TUI

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -4,7 +4,6 @@
 * mode state not preserved between actions, makes it impossible to build a confirm option
 * can't purchase items from the shop in TUI mode
 * can't reroll the shop in TUI mode
-* Jokers should always be visible in the game info box
 * TUI mode should maintain a trailing list of every event that occurs in the game and display it off to the right side of the screen
 * files are messily-strewn about. We should have separate directories for game logic, UIs, tests, documentation.
 * unit tests are almost non-existent. There's plenty of easy ones to write. Right now we're too dependent on manual testing.

--- a/internal/game/deck_shuffle_test.go
+++ b/internal/game/deck_shuffle_test.go
@@ -1,0 +1,21 @@
+package game
+
+import "testing"
+
+// TestShuffleDeckDeterministic ensures that shuffling with the same seed
+// produces the same card order.
+func TestShuffleDeckDeterministic(t *testing.T) {
+	SetSeed(99)
+	d1 := NewDeck()
+	ShuffleDeck(d1)
+
+	SetSeed(99)
+	d2 := NewDeck()
+	ShuffleDeck(d2)
+
+	for i := range d1 {
+		if d1[i] != d2[i] {
+			t.Fatalf("expected deterministic shuffle, card %d differs", i)
+		}
+	}
+}

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -757,15 +757,25 @@ func (g *Game) showShopWithItems(availableJokers []Joker, shopItems []Joker) {
 	}
 }
 
-// RemoveCards removes cards at specified indices and returns the new slice
+// removeCards removes cards at specified indices and returns the new slice
 func RemoveCards(cards []Card, indices []int) []Card {
-	// Sort indices in descending order to remove from end first
-	sort.Sort(sort.Reverse(sort.IntSlice(indices)))
+	// Use a set to ensure each index is only removed once
+	uniqueSet := make(map[int]struct{})
+	for _, idx := range indices {
+		uniqueSet[idx] = struct{}{}
+	}
+
+	// Collect unique indices and sort in descending order to remove from end first
+	uniqueIndices := make([]int, 0, len(uniqueSet))
+	for idx := range uniqueSet {
+		uniqueIndices = append(uniqueIndices, idx)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(uniqueIndices)))
 
 	result := make([]Card, len(cards))
 	copy(result, cards)
 
-	for _, index := range indices {
+	for _, index := range uniqueIndices {
 		if index >= 0 && index < len(result) {
 			result = append(result[:index], result[index+1:]...)
 		}

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -1,0 +1,151 @@
+package game
+
+import "testing"
+
+// testEventHandler is a minimal EventHandler implementation for testing.
+type testEventHandler struct {
+	events      []Event
+	shopActions []struct {
+		action PlayerAction
+		params []string
+	}
+	actionIdx int
+}
+
+func (t *testEventHandler) HandleEvent(e Event) {
+	t.events = append(t.events, e)
+}
+
+func (t *testEventHandler) GetPlayerAction(bool) (PlayerAction, []string, bool) {
+	return PlayerActionNone, nil, false
+}
+
+func (t *testEventHandler) GetShopAction() (PlayerAction, []string, bool) {
+	if t.actionIdx >= len(t.shopActions) {
+		return PlayerActionExitShop, nil, false
+	}
+	a := t.shopActions[t.actionIdx]
+	t.actionIdx++
+	return a.action, a.params, false
+}
+
+func (t *testEventHandler) Close() {}
+
+// TestHandlePlayAction verifies that playing cards updates score, hand count
+// and emits a HandPlayedEvent.
+func TestHandlePlayAction(t *testing.T) {
+	handler := &testEventHandler{}
+	deck := NewDeck()
+	g := &Game{
+		deck:         deck,
+		deckIndex:    7,
+		playerCards:  []Card{{Rank: Ten, Suit: Hearts}, {Rank: Ten, Suit: Clubs}, {Rank: Three, Suit: Diamonds}, {Rank: Four, Suit: Spades}, {Rank: Five, Suit: Hearts}, {Rank: Six, Suit: Clubs}, {Rank: Seven, Suit: Diamonds}},
+		eventEmitter: NewEventEmitter(),
+	}
+	g.eventEmitter.SetEventHandler(handler)
+
+	g.handlePlayAction([]string{"1", "2"})
+
+	if g.handsPlayed != 1 {
+		t.Fatalf("expected hands played to be 1, got %d", g.handsPlayed)
+	}
+	if g.totalScore <= 0 {
+		t.Fatalf("expected positive score, got %d", g.totalScore)
+	}
+	if len(g.playerCards) != 7 {
+		t.Fatalf("expected 7 cards after playing, got %d", len(g.playerCards))
+	}
+
+	found := false
+	for _, e := range handler.events {
+		if _, ok := e.(HandPlayedEvent); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected HandPlayedEvent to be emitted")
+	}
+}
+
+// TestHandleDiscardAction verifies discarding cards updates discard count and
+// emits a CardsDiscardedEvent.
+func TestHandleDiscardAction(t *testing.T) {
+	handler := &testEventHandler{}
+	deck := NewDeck()
+	g := &Game{
+		deck:         deck,
+		deckIndex:    7,
+		playerCards:  deck[:7],
+		eventEmitter: NewEventEmitter(),
+	}
+	g.eventEmitter.SetEventHandler(handler)
+
+	g.handleDiscardAction([]string{"1", "2"})
+
+	if g.discardsUsed != 1 {
+		t.Fatalf("expected 1 discard used, got %d", g.discardsUsed)
+	}
+	if len(g.playerCards) != 7 {
+		t.Fatalf("expected 7 cards after discard, got %d", len(g.playerCards))
+	}
+	found := false
+	for _, e := range handler.events {
+		if _, ok := e.(CardsDiscardedEvent); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected CardsDiscardedEvent to be emitted")
+	}
+}
+
+// TestShowShopWithItems ensures that purchasing an item deducts money, adds the
+// joker and emits the appropriate events.
+func TestShowShopWithItems(t *testing.T) {
+	handler := &testEventHandler{
+		shopActions: []struct {
+			action PlayerAction
+			params []string
+		}{
+			{PlayerActionBuy, []string{"1"}},
+			{PlayerActionExitShop, nil},
+		},
+	}
+
+	g := &Game{
+		money:        10,
+		rerollCost:   5,
+		jokers:       []Joker{},
+		eventEmitter: NewEventEmitter(),
+	}
+	g.eventEmitter.SetEventHandler(handler)
+
+	available := []Joker{{Name: "J1", Price: 5, Description: ""}, {Name: "J2", Price: 6, Description: ""}}
+	shop := []Joker{available[0], available[1]}
+
+	g.showShopWithItems(available, shop)
+
+	if g.money != 5 {
+		t.Fatalf("expected money to be 5 after purchase, got %d", g.money)
+	}
+	if len(g.jokers) != 1 || g.jokers[0].Name != "J1" {
+		t.Fatalf("expected to own J1 after purchase")
+	}
+	opened, purchased := false, false
+	for _, e := range handler.events {
+		switch e.(type) {
+		case ShopOpenedEvent:
+			opened = true
+		case ShopItemPurchasedEvent:
+			purchased = true
+		}
+	}
+	if !opened {
+		t.Fatalf("expected ShopOpenedEvent to be emitted")
+	}
+	if !purchased {
+		t.Fatalf("expected ShopItemPurchasedEvent to be emitted")
+	}
+}

--- a/internal/game/jokers_test.go
+++ b/internal/game/jokers_test.go
@@ -1,0 +1,36 @@
+package game
+
+import "testing"
+
+// TestCalculateJokerRewards verifies AddMoney joker rewards at blind end.
+func TestCalculateJokerRewards(t *testing.T) {
+	j := Joker{OnBlindEnd: func() int { return 4 }}
+	if got := CalculateJokerRewards([]Joker{j}); got != 4 {
+		t.Fatalf("expected 4, got %d", got)
+	}
+}
+
+// TestCalculateJokerHandBonus verifies chip and multiplier bonuses from jokers.
+func TestCalculateJokerHandBonus(t *testing.T) {
+	chipCfg := JokerConfig{Name: "Chip", Effect: AddChips, EffectMagnitude: 30, HandMatchingRule: ContainsPair}
+	chipJoker := createJokerFromConfig(chipCfg)
+
+	multCfg := JokerConfig{Name: "Mult", Effect: AddMult, EffectMagnitude: 5, HandMatchingRule: ContainsPair}
+	multJoker := createJokerFromConfig(multCfg)
+
+	chips, mult := CalculateJokerHandBonus([]Joker{chipJoker}, "Pair")
+	if chips != 30 || mult != 0 {
+		t.Fatalf("expected 30 chips bonus, got chips=%d mult=%d", chips, mult)
+	}
+
+	chips, mult = CalculateJokerHandBonus([]Joker{multJoker}, "Pair")
+	if chips != 0 || mult != 5 {
+		t.Fatalf("expected mult bonus 5, got chips=%d mult=%d", chips, mult)
+	}
+
+	// Non-matching hand should yield no bonus
+	chips, mult = CalculateJokerHandBonus([]Joker{chipJoker}, "High Card")
+	if chips != 0 || mult != 0 {
+		t.Fatalf("expected no bonus for non-matching hand, got chips=%d mult=%d", chips, mult)
+	}
+}

--- a/internal/game/logger_event_handler_test.go
+++ b/internal/game/logger_event_handler_test.go
@@ -1,4 +1,4 @@
-package main
+package game
 
 import (
 	"bufio"

--- a/internal/game/logger_event_handler_test.go
+++ b/internal/game/logger_event_handler_test.go
@@ -1,19 +1,34 @@
-package game
+package game_test
 
 import (
-	"bufio"
-	"strings"
-	"testing"
+        "bufio"
+        "reflect"
+        "strings"
+        "testing"
+        "unsafe"
+
+        game "balatno/internal/game"
 )
 
+// newHandlerWithInput creates a LoggerEventHandler with a custom input scanner.
+// The LoggerEventHandler's scanner field is unexported, so reflection is used to
+// inject our own scanner for testing.
+func newHandlerWithInput(input string) *game.LoggerEventHandler {
+        h := game.NewLoggerEventHandler()
+        scanner := bufio.NewScanner(strings.NewReader(input))
+        v := reflect.ValueOf(h).Elem().FieldByName("scanner")
+        reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().Set(reflect.ValueOf(scanner))
+        return h
+}
+
 func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
-	handler := &LoggerEventHandler{scanner: bufio.NewScanner(strings.NewReader("buy 12\n"))}
+	handler := newHandlerWithInput("buy 12\n")
 	action, params, quit := handler.GetShopAction()
 	if quit {
 		t.Fatalf("expected quit to be false, got true")
 	}
-	if action != PlayerActionBuy {
-		t.Fatalf("expected action %s, got %s", PlayerActionBuy, action)
+	if action != game.PlayerActionBuy {
+		t.Fatalf("expected action %s, got %s", game.PlayerActionBuy, action)
 	}
 	if len(params) != 1 || params[0] != "12" {
 		t.Fatalf("expected params [\"12\"], got %v", params)
@@ -21,13 +36,13 @@ func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
 }
 
 func TestGetShopActionParsesReroll(t *testing.T) {
-	handler := &LoggerEventHandler{scanner: bufio.NewScanner(strings.NewReader("reroll\n"))}
+	handler := newHandlerWithInput("reroll\n")
 	action, params, quit := handler.GetShopAction()
 	if quit {
 		t.Fatalf("expected quit to be false, got true")
 	}
-	if action != PlayerActionReroll {
-		t.Fatalf("expected action %s, got %s", PlayerActionReroll, action)
+	if action != game.PlayerActionReroll {
+		t.Fatalf("expected action %s, got %s", game.PlayerActionReroll, action)
 	}
 	if len(params) != 0 {
 		t.Fatalf("expected no params, got %v", params)

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -140,7 +140,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Game event messages
 	case gameStartedMsg:
 		m.setStatusMessage("🎮 Game started! Select cards with 1-7, play with Enter/P, discard with D")
-		m.mode = GameMode{}
+		m.mode = &GameMode{}
 		return m, nil
 
 	case gameStateChangedMsg:
@@ -247,7 +247,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		shopCopy := event
 		m.shopInfo = &shopCopy
 		m.gameState.Money = event.Money
-		m.mode = ShoppingMode{}
+		m.mode = &ShoppingMode{}
 		m.setStatusMessage("🛍️ Welcome to the Shop!")
 		return m, nil
 
@@ -276,7 +276,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case shopClosedMsg:
 		m.shopInfo = nil
 		m.setStatusMessage("👋 Left the shop")
-		m.mode = GameMode{}
+		m.mode = &GameMode{}
 		return m, nil
 
 	case invalidActionMsg:
@@ -319,7 +319,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // handleKeyPress processes keyboard input
-func (m TUIModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m *TUIModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Update last activity time on any key press
 	m.lastActivity = time.Now()
 
@@ -348,7 +348,7 @@ func (m TUIModel) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	// But mostly what the keypress should do is handled by the mode we're currently in
-	return m.mode.handleKeyPress(&m, msg.String())
+	return m.mode.handleKeyPress(m, msg.String())
 }
 
 // View renders the UI
@@ -384,7 +384,7 @@ func (m TUIModel) View() string {
 	// 	m.mode = m.mode.toggleHelp()
 	// }
 
-	content = m.mode.renderContent(m)
+	content = m.mode.renderContent(&m)
 
 	renderedContent := mainContentStyle.
 		Width(m.width).
@@ -409,7 +409,7 @@ func tickCmd() tea.Cmd {
 }
 
 type Mode interface {
-	renderContent(m TUIModel) string
+	renderContent(m *TUIModel) string
 	toggleHelp() Mode
 	handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd)
 	getControls() string

--- a/internal/ui/tui_game.go
+++ b/internal/ui/tui_game.go
@@ -12,11 +12,10 @@ import (
 	game "balatno/internal/game"
 )
 
-type GameMode struct {
-}
+type GameMode struct{}
 
 // renderContent renders the main game area
-func (gm GameMode) renderContent(m TUIModel) string {
+func (gm *GameMode) renderContent(m *TUIModel) string {
 	// Game status info - fixed height section
 	progress := float64(m.gameState.Score) / float64(m.gameState.Target)
 	if progress > 1.0 {
@@ -55,7 +54,7 @@ func (gm GameMode) renderContent(m TUIModel) string {
 		Height(5).
 		Render(gameInfo)
 
-	// Render hand - fixed height section
+		// Render hand - fixed height section
 	hand := renderHand(m)
 
 	return lipgloss.JoinVertical(
@@ -89,7 +88,7 @@ func renderCard(m TUIModel, card game.Card, isInSelectedArea bool) string {
 }
 
 // renderHand renders the player's current hand of cards
-func renderHand(m TUIModel) string {
+func renderHand(m *TUIModel) string {
 	if len(m.cards) == 0 {
 		return handStyle.Height(10).Render("No cards in hand")
 	}
@@ -101,7 +100,7 @@ func renderHand(m TUIModel) string {
 	var cardViews []string
 	for i, card := range m.cards {
 		isSelected := m.isCardSelected(i)
-		cardStr := renderCard(m, card, false)
+		cardStr := renderCard(*m, card, false)
 
 		// Add position number below the card
 		posNumStyle := lipgloss.NewStyle().
@@ -126,7 +125,7 @@ func renderHand(m TUIModel) string {
 	return handStyle.Height(10).Render(content.String())
 }
 
-func (gm GameMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
+func (gm *GameMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
 	// Update last activity time on any key press
 	m.lastActivity = time.Now()
 
@@ -171,18 +170,18 @@ func (gm GameMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) 
 	return m, nil
 }
 
-func (gm GameMode) toggleHelp() Mode {
+func (gm *GameMode) toggleHelp() Mode {
 	return &GameHelpMode{}
 }
 
-func (gm GameMode) getControls() string {
+func (gm *GameMode) getControls() string {
 	return " | 1-7: select cards, Enter/P: play, D: discard, C: clear, R: resort, H: help, Q: quit"
 }
 
 type GameHelpMode struct{}
 
 // renderHelp renders the help screen
-func (gm GameHelpMode) renderContent(m TUIModel) string {
+func (gm GameHelpMode) renderContent(m *TUIModel) string {
 	helpStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("33")).

--- a/internal/ui/tui_game.go
+++ b/internal/ui/tui_game.go
@@ -50,8 +50,25 @@ func (gm *GameMode) renderContent(m *TUIModel) string {
 		fmt.Sprintf("🎴 Hands Left: %d | 🗑️ Discards Left: %d | 💰 Money: $%d",
 			m.gameState.Hands, m.gameState.Discards, m.gameState.Money)
 
+	// Add joker information
+	var jokerLines []string
+	if len(m.gameState.Jokers) == 0 {
+		jokerLines = append(jokerLines, "🃏 Jokers: None")
+	} else {
+		jokerLines = append(jokerLines, "🃏 Jokers:")
+		for _, joker := range m.gameState.Jokers {
+			jokerLines = append(jokerLines, renderOwnedJoker(joker))
+		}
+	}
+	gameInfo += "\n" + strings.Join(jokerLines, "\n")
+
+	infoHeight := 3 + len(jokerLines)
+	if infoHeight < 5 {
+		infoHeight = 5
+	}
+
 	gameInfoBox := gameInfoStyle.
-		Height(5).
+		Height(infoHeight).
 		Render(gameInfo)
 
 		// Render hand - fixed height section
@@ -125,9 +142,14 @@ func renderHand(m *TUIModel) string {
 	return handStyle.Height(10).Render(content.String())
 }
 
+// renderOwnedJoker renders a joker the player currently owns
+func renderOwnedJoker(joker game.Joker) string {
+        return fmt.Sprintf("%s: %s", joker.Name, joker.Description)
+}
+
 func (gm *GameMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
-	// Update last activity time on any key press
-	m.lastActivity = time.Now()
+        // Update last activity time on any key press
+        m.lastActivity = time.Now()
 
 	switch msg {
 	// there's a bug when you discard and then attempt to play, it won't submit.

--- a/internal/ui/tui_shop.go
+++ b/internal/ui/tui_shop.go
@@ -16,7 +16,7 @@ type ShoppingMode struct {
 	consecutiveEnters int
 }
 
-func (ms ShoppingMode) renderContent(m TUIModel) string {
+func (ms *ShoppingMode) renderContent(m *TUIModel) string {
 	gameInfo := fmt.Sprintf("%s Ante %d - %s✅\n", "🏪", m.gameState.Ante, m.gameState.Blind) +
 		fmt.Sprintf("🎴 Hands: %d | 🗑️ Discards: %d | 💰 Money: $%d | 🎲 Reroll: $%d",
 			m.gameState.Hands, m.gameState.Discards, m.gameState.Money, m.shopInfo.RerollCost)
@@ -27,7 +27,7 @@ func (ms ShoppingMode) renderContent(m TUIModel) string {
 	var jokerViews []string
 
 	for idx, joker := range m.shopInfo.Items {
-		jokerStr := renderJoker(m, joker)
+		jokerStr := renderJoker(*m, joker)
 
 		posNumStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("244"))
@@ -51,7 +51,7 @@ func (ms ShoppingMode) renderContent(m TUIModel) string {
 	)
 }
 
-func (gm ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
+func (gm *ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
 	// Update last activity time on any key press
 	m.lastActivity = time.Now()
 
@@ -153,11 +153,11 @@ func renderJoker(m TUIModel, joker game.ShopItemData) string {
 	return jokerStr
 }
 
-func (gm ShoppingMode) toggleHelp() Mode {
+func (gm *ShoppingMode) toggleHelp() Mode {
 	return &ShopHelpMode{}
 }
 
-func (gm ShoppingMode) getControls() string {
+func (gm *ShoppingMode) getControls() string {
 	// TODO I do think we'll need the game state to know how many shop items are available
 	// but for now hardcode to 4
 	return " | 1-4: select item, Enter (with selected): purchase, Enter (without selected): exit, C: clear, R: reroll, H: help, ESC: exit, Q: quit"
@@ -166,7 +166,7 @@ func (gm ShoppingMode) getControls() string {
 type ShopHelpMode struct{}
 
 // renderHelp renders the help screen
-func (gm ShopHelpMode) renderContent(m TUIModel) string {
+func (gm ShopHelpMode) renderContent(m *TUIModel) string {
 	return "you're in the shop, brother"
 }
 

--- a/internal/ui/tui_shop.go
+++ b/internal/ui/tui_shop.go
@@ -32,7 +32,7 @@ func (ms *ShoppingMode) renderContent(m *TUIModel) string {
 		posNumStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("244"))
 
-		if m.isCardSelected(idx) {
+		if ms.selectedItem != nil && *ms.selectedItem == idx+1 {
 			posNumStyle = posNumStyle.Foreground(lipgloss.Color("226")).Bold(true)
 		}
 
@@ -69,9 +69,9 @@ func (gm *ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.
 		return m, nil
 
 	case "enter":
-		// Exit the shop
 		if gm.selectedItem != nil {
-			item := m.shopInfo.Items[*gm.selectedItem]
+			idx := *gm.selectedItem - 1
+			item := m.shopInfo.Items[idx]
 			if !item.CanAfford {
 				m.setStatusMessage("Not enough money!")
 				return m, nil
@@ -88,19 +88,12 @@ func (gm *ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.
 						Quit:   false,
 					}
 				}()
-
-				m.setStatusMessage("🚪 Exiting shop...")
 			}
-			// m.cards = append(m.cards, item)
+
 			m.setStatusMessage(fmt.Sprintf("🛒 Purchased %s!", item.Name))
+			gm.selectedItem = nil
 			return m, nil
 		}
-
-		// if gm.consecutiveEnters == 0 {
-		// 	gm.consecutiveEnters++
-		// 	m.setStatusMessage("Press 'Enter' again to exit shop")
-		// 	return m, nil
-		// }
 
 		if m.actionRequestPending != nil {
 			// Capture response channel before clearing the pending request
@@ -119,7 +112,6 @@ func (gm *ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.
 			m.setStatusMessage("🚪 Exiting shop...")
 		}
 		return m, nil
-
 	case "r":
 		// Reroll shop items
 		if m.actionRequestPending != nil {

--- a/internal/ui/tui_shop.go
+++ b/internal/ui/tui_shop.go
@@ -1,184 +1,146 @@
 package ui
 
 import (
-	"fmt"
-	"strconv"
-	"time"
+        "fmt"
+        "strconv"
+        "time"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
+        tea "github.com/charmbracelet/bubbletea"
+        "github.com/charmbracelet/lipgloss"
 
-	game "balatno/internal/game"
+        game "balatno/internal/game"
 )
 
 type ShoppingMode struct {
-	selectedItem      *int
-	consecutiveEnters int
+        selectedItem      *int
+        consecutiveEnters int
 }
 
 func (ms *ShoppingMode) renderContent(m *TUIModel) string {
-	gameInfo := fmt.Sprintf("%s Ante %d - %s✅\n", "🏪", m.gameState.Ante, m.gameState.Blind) +
-		fmt.Sprintf("🎴 Hands: %d | 🗑️ Discards: %d | 💰 Money: $%d | 🎲 Reroll: $%d",
-			m.gameState.Hands, m.gameState.Discards, m.gameState.Money, m.shopInfo.RerollCost)
-	gameInfoBox := gameInfoStyle.
-		Height(5).
-		Render(gameInfo)
+        gameInfo := fmt.Sprintf("%s Ante %d - %s✅\n", "🏪", m.gameState.Ante, m.gameState.Blind) +
+                fmt.Sprintf("🎴 Hands: %d | 🗑️ Discards: %d | 💰 Money: $%d | 🎲 Reroll: $%d",
+                        m.gameState.Hands, m.gameState.Discards, m.gameState.Money, m.shopInfo.RerollCost)
+        gameInfoBox := gameInfoStyle.
+                Height(5).
+                Render(gameInfo)
 
-	var jokerViews []string
+        var jokerViews []string
 
-	for idx, joker := range m.shopInfo.Items {
-		jokerStr := renderJoker(*m, joker)
+        for idx, joker := range m.shopInfo.Items {
+                jokerStr := renderJoker(*m, joker)
 
-		posNumStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("244"))
+                posNumStyle := lipgloss.NewStyle().
+                        Foreground(lipgloss.Color("244"))
 
-		if ms.selectedItem != nil && *ms.selectedItem == idx+1 {
-			posNumStyle = posNumStyle.Foreground(lipgloss.Color("226")).Bold(true)
-		}
+                if ms.selectedItem != nil && *ms.selectedItem == idx+1 {
+                        posNumStyle = posNumStyle.Foreground(lipgloss.Color("226")).Bold(true)
+                }
 
-		positionNum := posNumStyle.Render(fmt.Sprintf("%d", idx+1))
+                positionNum := posNumStyle.Render(fmt.Sprintf("%d", idx+1))
 
-		jokerWithPos := lipgloss.JoinHorizontal(lipgloss.Left, positionNum, jokerStr)
-		jokerViews = append(jokerViews, jokerWithPos)
-	}
+                jokerWithPos := lipgloss.JoinHorizontal(lipgloss.Left, positionNum, jokerStr)
+                jokerViews = append(jokerViews, jokerWithPos)
+        }
 
-	jokerDisplay := gameInfoStyle.Height(len(jokerViews)).Render(lipgloss.JoinVertical(lipgloss.Top, jokerViews...))
+        jokerDisplay := gameInfoStyle.Height(len(jokerViews)).Render(lipgloss.JoinVertical(lipgloss.Top, jokerViews...))
 
-	return lipgloss.JoinVertical(
-		lipgloss.Left,
-		gameInfoBox,
-		jokerDisplay,
-	)
+        return lipgloss.JoinVertical(
+                lipgloss.Left,
+                gameInfoBox,
+                jokerDisplay,
+        )
 }
 
 func (gm *ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
-	// Update last activity time on any key press
-	m.lastActivity = time.Now()
+        // Update last activity time on any key press
+        m.lastActivity = time.Now()
 
-	switch msg {
-	case "1", "2", "3", "4", "5", "6", "7":
-		// select a shop item
-		i := int(msg[0] - '0')
+        switch msg {
+        case "1", "2", "3", "4", "5", "6", "7":
+                // select a shop item
+                i := int(msg[0] - '0')
 
-		item := m.shopInfo.Items[i-1]
-		if !item.CanAfford {
-			m.setStatusMessage("Not enough money!")
-			return m, nil
-		}
-		gm.selectedItem = &i
-		return m, nil
+                item := m.shopInfo.Items[i-1]
+                if !item.CanAfford {
+                        m.setStatusMessage("Not enough money!")
+                        return m, nil
+                }
+                gm.selectedItem = &i
+                return m, nil
 
-	case "enter":
-		if gm.selectedItem != nil {
-			idx := *gm.selectedItem - 1
-			item := m.shopInfo.Items[idx]
-			if !item.CanAfford {
-				m.setStatusMessage("Not enough money!")
-				return m, nil
-			}
+        case "enter":
+                if gm.selectedItem != nil {
+                        idx := *gm.selectedItem - 1
+                        item := m.shopInfo.Items[idx]
+                        if !item.CanAfford {
+                                m.setStatusMessage("Not enough money!")
+                                return m, nil
+                        }
 
-			if m.actionRequestPending != nil {
-				responseChan := m.actionRequestPending.ResponseChan
-				m.actionRequestPending = nil
+                        m.sendAction(game.PlayerActionBuy, []string{strconv.Itoa(idx)})
+                        m.setStatusMessage(fmt.Sprintf("🛒 Purchased %s!", item.Name))
+                        gm.selectedItem = nil
+                        return m, nil
+                }
 
-				go func() {
-					responseChan <- PlayerActionResponse{
-						Action: game.PlayerActionBuy,
-						Params: []string{strconv.Itoa(*gm.selectedItem)},
-						Quit:   false,
-					}
-				}()
-			}
+                m.sendAction(game.PlayerActionExitShop, nil)
+                m.setStatusMessage("🚪 Exiting shop...")
+                return m, nil
 
-			m.setStatusMessage(fmt.Sprintf("🛒 Purchased %s!", item.Name))
-			gm.selectedItem = nil
-			return m, nil
-		}
-
-		if m.actionRequestPending != nil {
-			// Capture response channel before clearing the pending request
-			responseChan := m.actionRequestPending.ResponseChan
-			m.actionRequestPending = nil
-
-			// Send exit shop response
-			go func() {
-				responseChan <- PlayerActionResponse{
-					Action: game.PlayerActionExitShop,
-					Params: nil,
-					Quit:   false,
-				}
-			}()
-
-			m.setStatusMessage("🚪 Exiting shop...")
-		}
-		return m, nil
-	case "r":
-		// Reroll shop items
-		if m.actionRequestPending != nil {
-			// Capture response channel before clearing the pending request
-			responseChan := m.actionRequestPending.ResponseChan
-			m.actionRequestPending = nil
-
-			// Send reroll response
-			go func() {
-				responseChan <- PlayerActionResponse{
-					Action: game.PlayerActionReroll,
-					Params: nil,
-					Quit:   false,
-				}
-			}()
-
-			m.setStatusMessage("🎲 Rerolling shop items...")
-		}
-		return m, nil
-	}
-	return m, nil
+        case "r":
+                // Reroll shop items
+                m.sendAction(game.PlayerActionReroll, nil)
+                m.setStatusMessage("🎲 Rerolling shop items...")
+                return m, nil
+        }
+        return m, nil
 }
 
 func renderJoker(m TUIModel, joker game.ShopItemData) string {
-	cost := fmt.Sprintf("%d", joker.Cost)
-	if joker.Cost > m.gameState.Money {
-		cost = lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Render(cost)
-	}
-	jokerStr := fmt.Sprintf("%s ($%s): %s\n", joker.Name, cost, joker.Description)
+        cost := fmt.Sprintf("%d", joker.Cost)
+        if joker.Cost > m.gameState.Money {
+                cost = lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Render(cost)
+        }
+        jokerStr := fmt.Sprintf("%s ($%s): %s\n", joker.Name, cost, joker.Description)
 
-	return jokerStr
+        return jokerStr
 }
 
 func (gm *ShoppingMode) toggleHelp() Mode {
-	return &ShopHelpMode{}
+        return &ShopHelpMode{}
 }
 
 func (gm *ShoppingMode) getControls() string {
-	// TODO I do think we'll need the game state to know how many shop items are available
-	// but for now hardcode to 4
-	return " | 1-4: select item, Enter (with selected): purchase, Enter (without selected): exit, C: clear, R: reroll, H: help, ESC: exit, Q: quit"
+        // TODO I do think we'll need the game state to know how many shop items are available
+        // but for now hardcode to 4
+        return " | 1-4: select item, Enter (with selected): purchase, Enter (without selected): exit, C: clear, R: reroll, H: help, ESC: exit, Q: quit"
 }
 
 type ShopHelpMode struct{}
 
 // renderHelp renders the help screen
 func (gm ShopHelpMode) renderContent(m *TUIModel) string {
-	return "you're in the shop, brother"
+        return "you're in the shop, brother"
 }
 
 func (gm ShopHelpMode) toggleHelp() Mode {
-	return &ShoppingMode{}
+        return &ShoppingMode{}
 }
 
 func (gm ShopHelpMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
-	// Update last activity time on any key press
-	m.lastActivity = time.Now()
-	// fmt.Println(msg)
-	m.setStatusMessage(msg)
-	if msg == "esc" || msg == "escape" || msg == "enter" {
-		m.showHelp = !m.showHelp
-		m.mode = gm.toggleHelp()
-	}
+        // Update last activity time on any key press
+        m.lastActivity = time.Now()
+        // fmt.Println(msg)
+        m.setStatusMessage(msg)
+        if msg == "esc" || msg == "escape" || msg == "enter" {
+                m.showHelp = !m.showHelp
+                m.mode = gm.toggleHelp()
+        }
 
-	return m, nil
+        return m, nil
 }
 
 func (gm ShopHelpMode) getControls() string {
-	return " | Enter/Esc/H: exit help, Q: quit"
+        return " | Enter/Esc/H: exit help, Q: quit"
 }
+

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	game "balatno/internal/game"
+)
+
+// TestToggleCardSelection verifies selecting and deselecting cards.
+func TestToggleCardSelection(t *testing.T) {
+	m := TUIModel{cards: []game.Card{{Rank: game.Ace, Suit: game.Spades}}}
+
+	if m.isCardSelected(0) {
+		t.Fatalf("card should not be selected initially")
+	}
+
+	m.toggleCardSelection(0)
+	if !m.isCardSelected(0) {
+		t.Fatalf("card should be selected after toggle")
+	}
+
+	m.toggleCardSelection(0)
+	if m.isCardSelected(0) {
+		t.Fatalf("card should be deselected after second toggle")
+	}
+}
+
+// TestHelpToggle ensures that pressing 'h' toggles help mode on and off.
+func TestHelpToggle(t *testing.T) {
+        m := TUIModel{mode: &GameMode{}}
+
+        model, _ := m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+        m = *model.(*TUIModel)
+
+	if !m.showHelp {
+		t.Fatalf("expected help to be shown")
+	}
+	if _, ok := m.mode.(*GameHelpMode); !ok {
+		t.Fatalf("expected mode to be GameHelpMode")
+	}
+
+        model, _ = m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+        m = *model.(*TUIModel)
+
+	if m.showHelp {
+		t.Fatalf("expected help to be hidden")
+	}
+	if _, ok := m.mode.(*GameMode); !ok {
+		t.Fatalf("expected mode to be GameMode after toggling back")
+	}
+}
+
+// TestShoppingModeActions verifies purchase and reroll flows in the shop.
+func TestShoppingModeActions(t *testing.T) {
+	// Prepare a model with one affordable item and a pending request
+	respChan := make(chan PlayerActionResponse, 1)
+        selected := 1
+        m := TUIModel{
+                gameState:            game.GameStateChangedEvent{Money: 10},
+                shopInfo:             &game.ShopOpenedEvent{Money: 10, RerollCost: 5, Items: []game.ShopItemData{{Name: "J1", Cost: 5, Description: "", CanAfford: true}}},
+                mode:                 &ShoppingMode{selectedItem: &selected},
+                actionRequestPending: &PlayerActionRequest{ResponseChan: respChan},
+        }
+
+	// Purchasing selected item
+	model, _ := m.handleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	resp := <-respChan
+	if resp.Action != game.PlayerActionBuy || len(resp.Params) != 1 || resp.Params[0] != "0" {
+		t.Fatalf("unexpected purchase response: %+v", resp)
+	}
+
+	// Reroll action
+	respChan = make(chan PlayerActionResponse, 1)
+	mPtr := model.(*TUIModel)
+	m = *mPtr
+	m.actionRequestPending = &PlayerActionRequest{ResponseChan: respChan}
+        m.mode = &ShoppingMode{}
+	model, _ = m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	resp = <-respChan
+	if resp.Action != game.PlayerActionReroll {
+		t.Fatalf("unexpected reroll response: %+v", resp)
+	}
+}


### PR DESCRIPTION
## Summary
- Switch Mode interface to consume `*TUIModel` and store mode instances as pointers
- Convert GameMode and ShoppingMode methods to pointer receivers
- Preserve mode-specific state like selected shop item across key presses

## Testing
- `go test ./...` *(fails: undefined LoggerEventHandler)*
- `go test ./internal/... ./tests`


------
https://chatgpt.com/codex/tasks/task_e_689949e957f0832ca789bbbf3625245c