### PR TITLE
Display owned jokers in game info box

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -4,7 +4,6 @@
 * mode state not preserved between actions, makes it impossible to build a confirm option
 * can't purchase items from the shop in TUI mode
 * can't reroll the shop in TUI mode
-* Jokers should always be visible in the game info box
 * TUI mode should maintain a trailing list of every event that occurs in the game and display it off to the right side of the screen
 * files are messily-strewn about. We should have separate directories for game logic, UIs, tests, documentation.
 * unit tests are almost non-existent. There's plenty of easy ones to write. Right now we're too dependent on manual testing.

--- a/internal/ui/tui_game.go
+++ b/internal/ui/tui_game.go
@@ -51,8 +51,25 @@ func (gm GameMode) renderContent(m TUIModel) string {
 		fmt.Sprintf("🎴 Hands Left: %d | 🗑️ Discards Left: %d | 💰 Money: $%d",
 			m.gameState.Hands, m.gameState.Discards, m.gameState.Money)
 
+	// Add joker information
+	var jokerLines []string
+	if len(m.gameState.Jokers) == 0 {
+		jokerLines = append(jokerLines, "🃏 Jokers: None")
+	} else {
+		jokerLines = append(jokerLines, "🃏 Jokers:")
+		for _, joker := range m.gameState.Jokers {
+			jokerLines = append(jokerLines, renderOwnedJoker(joker))
+		}
+	}
+	gameInfo += "\n" + strings.Join(jokerLines, "\n")
+
+	infoHeight := 3 + len(jokerLines)
+	if infoHeight < 5 {
+		infoHeight = 5
+	}
+
 	gameInfoBox := gameInfoStyle.
-		Height(5).
+		Height(infoHeight).
 		Render(gameInfo)
 
 	// Render hand - fixed height section
@@ -124,6 +141,11 @@ func renderHand(m TUIModel) string {
 	content.WriteString(cardsDisplay)
 
 	return handStyle.Height(10).Render(content.String())
+}
+
+// renderOwnedJoker renders a joker the player currently owns
+func renderOwnedJoker(joker game.Joker) string {
+	return fmt.Sprintf("%s: %s", joker.Name, joker.Description)
 }
 
 func (gm GameMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
## Summary
- list player jokers and their effects in the main game info box
- add helper for rendering owned jokers
- remove outdated known issue entry about missing joker display

## Testing
- `go build ./...`
- `go test ./...` *(fails: undefined LoggerEventHandler, PlayerActionBuy, PlayerActionReroll)*

------
https://chatgpt.com/codex/tasks/task_e_689949ee5450832c8fa44216dbf38ce9