### PR TITLE
Add event log sidebar to TUI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,16 @@ go 1.23.0
 
 toolchain go1.24.2
 
-require gopkg.in/yaml.v2 v2.4.0
+require (
+	github.com/charmbracelet/bubbles v0.21.0
+	github.com/charmbracelet/bubbletea v1.3.6
+	github.com/charmbracelet/lipgloss v1.1.0
+	gopkg.in/yaml.v2 v2.4.0
+)
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbletea v1.3.6 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
+github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
 github.com/charmbracelet/bubbletea v1.3.6 h1:VkHIxPJQeDt0aFJIsVxw8BQdh/F/L2KKZGsK6et5taU=
 github.com/charmbracelet/bubbletea v1.3.6/go.mod h1:oQD9VCRQFF8KplacJLo28/jofOI2ToOfGYeFgBBxHOc=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
@@ -33,6 +35,8 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/game/logger_event_handler.go
+++ b/internal/game/logger_event_handler.go
@@ -3,6 +3,7 @@ package game
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -12,11 +13,16 @@ type LoggerEventHandler struct {
 	scanner *bufio.Scanner
 }
 
-// NewLoggerEventHandler creates a new LoggerEventHandler
+// NewLoggerEventHandler creates a new LoggerEventHandler using stdin for input
 func NewLoggerEventHandler() *LoggerEventHandler {
-	return &LoggerEventHandler{
-		scanner: bufio.NewScanner(os.Stdin),
-	}
+	return NewLoggerEventHandlerFromReader(os.Stdin)
+}
+
+// NewLoggerEventHandlerFromReader creates a new LoggerEventHandler that reads
+// input from the provided reader. Useful for tests where a custom input source
+// is needed.
+func NewLoggerEventHandlerFromReader(r io.Reader) *LoggerEventHandler {
+	return &LoggerEventHandler{scanner: bufio.NewScanner(r)}
 }
 
 // HandleEvent processes game events and presents them to the console

--- a/internal/game/logger_event_handler_test.go
+++ b/internal/game/logger_event_handler_test.go
@@ -1,4 +1,4 @@
-package main
+package game
 
 import (
 	"bufio"
@@ -6,15 +6,13 @@ import (
 	"strings"
 	"testing"
 	"unsafe"
-
-	game "balatno/internal/game"
 )
 
 // newHandlerWithInput creates a LoggerEventHandler with a custom input scanner.
 // The LoggerEventHandler's scanner field is unexported, so reflection is used to
 // inject our own scanner for testing.
-func newHandlerWithInput(input string) *game.LoggerEventHandler {
-	h := game.NewLoggerEventHandler()
+func newHandlerWithInput(input string) *LoggerEventHandler {
+	h := NewLoggerEventHandler()
 	scanner := bufio.NewScanner(strings.NewReader(input))
 	v := reflect.ValueOf(h).Elem().FieldByName("scanner")
 	reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().Set(reflect.ValueOf(scanner))
@@ -22,13 +20,13 @@ func newHandlerWithInput(input string) *game.LoggerEventHandler {
 }
 
 func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
-	handler := game.NewLoggerEventHandlerFromReader(strings.NewReader("buy 12\n"))
+	handler := NewLoggerEventHandlerFromReader(strings.NewReader("buy 12\n"))
 	action, params, quit := handler.GetShopAction()
 	if quit {
 		t.Fatalf("expected quit to be false, got true")
 	}
-	if action != game.PlayerActionBuy {
-		t.Fatalf("expected action %s, got %s", game.PlayerActionBuy, action)
+	if action != PlayerActionBuy {
+		t.Fatalf("expected action %s, got %s", PlayerActionBuy, action)
 	}
 	if len(params) != 1 || params[0] != "12" {
 		t.Fatalf("expected params [\"12\"], got %v", params)
@@ -36,13 +34,13 @@ func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
 }
 
 func TestGetShopActionParsesReroll(t *testing.T) {
-	handler := game.NewLoggerEventHandlerFromReader(strings.NewReader("reroll\n"))
+	handler := NewLoggerEventHandlerFromReader(strings.NewReader("reroll\n"))
 	action, params, quit := handler.GetShopAction()
 	if quit {
 		t.Fatalf("expected quit to be false, got true")
 	}
-	if action != game.PlayerActionReroll {
-		t.Fatalf("expected action %s, got %s", game.PlayerActionReroll, action)
+	if action != PlayerActionReroll {
+		t.Fatalf("expected action %s, got %s", PlayerActionReroll, action)
 	}
 	if len(params) != 0 {
 		t.Fatalf("expected no params, got %v", params)

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -389,13 +389,23 @@ func (m TUIModel) View() string {
 	}
 
 	// Top bar
+	topFrame, _ := topBarStyle.GetFrameSize()
+	topWidth := m.width - topFrame
+	if topWidth < 0 {
+		topWidth = 0
+	}
 	topBar := topBarStyle.
-		Width(m.width).
+		Width(topWidth).
 		Render("🃏 Welcome to Balatno")
 
 	// Status bar (second from bottom)
+	barFrame, _ := bottomBarStyle.GetFrameSize()
+	barWidth := m.width - barFrame
+	if barWidth < 0 {
+		barWidth = 0
+	}
 	statusBar := bottomBarStyle.
-		Width(m.width).
+		Width(barWidth).
 		Render(m.getStatusMessage())
 
 	// Bottom bar with time and controls
@@ -404,7 +414,7 @@ func (m TUIModel) View() string {
 	timeoutStr := fmt.Sprintf("%.0fs", timeoutRemaining.Seconds())
 	controls := "⏰ " + timeStr + " | Timeout: " + timeoutStr + m.mode.getControls()
 	bottomBar := bottomBarStyle.
-		Width(m.width).
+		Width(barWidth).
 		Render(controls)
 
 	// Main content area - fixed height

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -418,9 +418,17 @@ func (m TUIModel) View() string {
 	content = m.mode.renderContent(m)
 
 	logWidth := 30
-	contentWidth := m.width - logWidth
+	logFrame, _ := eventLogStyle.GetFrameSize()
+	logContentWidth := logWidth - logFrame
+	if logContentWidth < 0 {
+		logContentWidth = 0
+	}
+
+	contentAreaWidth := m.width - logWidth
+	mainFrame, _ := mainContentStyle.GetFrameSize()
+	contentWidth := contentAreaWidth - mainFrame
 	if contentWidth < 0 {
-		contentWidth = m.width
+		contentWidth = 0
 	}
 
 	renderedContent := mainContentStyle.
@@ -429,7 +437,7 @@ func (m TUIModel) View() string {
 		Render(content)
 
 	logView := eventLogStyle.
-		Width(logWidth).
+		Width(logContentWidth).
 		Height(contentHeight).
 		Render(m.renderEventLog(contentHeight))
 

--- a/internal/ui/tui_styles.go
+++ b/internal/ui/tui_styles.go
@@ -30,6 +30,11 @@ var (
 			Padding(1).
 			Margin(1, 1)
 
+	eventLogStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("240")).
+			Padding(0, 1)
+
 	heartsCardStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("196")).
 			Margin(0, 1)

--- a/logger_event_handler_test.go
+++ b/logger_event_handler_test.go
@@ -22,7 +22,7 @@ func newHandlerWithInput(input string) *game.LoggerEventHandler {
 }
 
 func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
-	handler := newHandlerWithInput("buy 12\n")
+	handler := game.NewLoggerEventHandlerFromReader(strings.NewReader("buy 12\n"))
 	action, params, quit := handler.GetShopAction()
 	if quit {
 		t.Fatalf("expected quit to be false, got true")
@@ -36,7 +36,7 @@ func TestGetShopActionParsesBuyWithQuantity(t *testing.T) {
 }
 
 func TestGetShopActionParsesReroll(t *testing.T) {
-	handler := newHandlerWithInput("reroll\n")
+	handler := game.NewLoggerEventHandlerFromReader(strings.NewReader("reroll\n"))
 	action, params, quit := handler.GetShopAction()
 	if quit {
 		t.Fatalf("expected quit to be false, got true")


### PR DESCRIPTION
## Summary
- Introduce an event log to `TUIModel` and initialize it
- Log game and shop events and render them in a right-side log panel
- Add styling for the new event log sidebar

## Testing
- `go test ./...` *(fails: LoggerEventHandler undefined)*

------
https://chatgpt.com/codex/tasks/task_e_689949fc6274832cbe53287cadd4732c