### PR TITLE
Fix shop selection persistence and exit

### DIFF
--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -247,7 +247,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		shopCopy := event
 		m.shopInfo = &shopCopy
 		m.gameState.Money = event.Money
-		m.mode = ShoppingMode{}
+		m.mode = &ShoppingMode{}
 		m.setStatusMessage("🛍️ Welcome to the Shop!")
 		return m, nil
 

--- a/internal/ui/tui_shop.go
+++ b/internal/ui/tui_shop.go
@@ -51,7 +51,7 @@ func (ms ShoppingMode) renderContent(m TUIModel) string {
 	)
 }
 
-func (gm ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
+func (gm *ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
 	// Update last activity time on any key press
 	m.lastActivity = time.Now()
 

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -60,7 +60,7 @@ func TestShoppingModeActions(t *testing.T) {
 	m := TUIModel{
 		gameState:            game.GameStateChangedEvent{Money: 10},
 		shopInfo:             &game.ShopOpenedEvent{Money: 10, RerollCost: 5, Items: []game.ShopItemData{{Name: "J1", Cost: 5, Description: "", CanAfford: true}}},
-		mode:                 ShoppingMode{selectedItem: &selected},
+		mode:                 &ShoppingMode{selectedItem: &selected},
 		actionRequestPending: &PlayerActionRequest{ResponseChan: respChan},
 	}
 
@@ -76,7 +76,7 @@ func TestShoppingModeActions(t *testing.T) {
 	mPtr := model.(*TUIModel)
 	m = *mPtr
 	m.actionRequestPending = &PlayerActionRequest{ResponseChan: respChan}
-	m.mode = ShoppingMode{}
+	m.mode = &ShoppingMode{}
 	model, _ = m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	resp = <-respChan
 	if resp.Action != game.PlayerActionReroll {


### PR DESCRIPTION
## Summary
- Ensure ShoppingMode uses a pointer receiver so item selections persist
- Open shop with a pointer-based ShoppingMode and adjust tests accordingly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68995a08fce4832cb5b135bdf85c51a5