### PR TITLE
Use pointer-based modes in TUI

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,7 +95,7 @@ The TUI implements a sophisticated mode system that handles different game state
 
 ```go
 type Mode interface {
-    renderContent(m TUIModel) string
+    renderContent(m *TUIModel) string
     toggleHelp() Mode
     handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd)
     getControls() string

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -140,7 +140,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Game event messages
 	case gameStartedMsg:
 		m.setStatusMessage("🎮 Game started! Select cards with 1-7, play with Enter/P, discard with D")
-		m.mode = GameMode{}
+		m.mode = &GameMode{}
 		return m, nil
 
 	case gameStateChangedMsg:
@@ -247,7 +247,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		shopCopy := event
 		m.shopInfo = &shopCopy
 		m.gameState.Money = event.Money
-		m.mode = ShoppingMode{}
+		m.mode = &ShoppingMode{}
 		m.setStatusMessage("🛍️ Welcome to the Shop!")
 		return m, nil
 
@@ -276,7 +276,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case shopClosedMsg:
 		m.shopInfo = nil
 		m.setStatusMessage("👋 Left the shop")
-		m.mode = GameMode{}
+		m.mode = &GameMode{}
 		return m, nil
 
 	case invalidActionMsg:
@@ -384,7 +384,7 @@ func (m TUIModel) View() string {
 	// 	m.mode = m.mode.toggleHelp()
 	// }
 
-	content = m.mode.renderContent(m)
+	content = m.mode.renderContent(&m)
 
 	renderedContent := mainContentStyle.
 		Width(m.width).
@@ -409,7 +409,7 @@ func tickCmd() tea.Cmd {
 }
 
 type Mode interface {
-	renderContent(m TUIModel) string
+	renderContent(m *TUIModel) string
 	toggleHelp() Mode
 	handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd)
 	getControls() string

--- a/internal/ui/tui_game.go
+++ b/internal/ui/tui_game.go
@@ -16,7 +16,7 @@ type GameMode struct {
 }
 
 // renderContent renders the main game area
-func (gm GameMode) renderContent(m TUIModel) string {
+func (gm *GameMode) renderContent(m *TUIModel) string {
 	// Game status info - fixed height section
 	progress := float64(m.gameState.Score) / float64(m.gameState.Target)
 	if progress > 1.0 {
@@ -72,8 +72,8 @@ func (gm GameMode) renderContent(m TUIModel) string {
 		Height(infoHeight).
 		Render(gameInfo)
 
-	// Render hand - fixed height section
-	hand := renderHand(m)
+		// Render hand - fixed height section
+	hand := renderHand(*m)
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
@@ -148,7 +148,7 @@ func renderOwnedJoker(joker game.Joker) string {
 	return fmt.Sprintf("%s: %s", joker.Name, joker.Description)
 }
 
-func (gm GameMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
+func (gm *GameMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
 	// Update last activity time on any key press
 	m.lastActivity = time.Now()
 
@@ -193,18 +193,18 @@ func (gm GameMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) 
 	return m, nil
 }
 
-func (gm GameMode) toggleHelp() Mode {
+func (gm *GameMode) toggleHelp() Mode {
 	return &GameHelpMode{}
 }
 
-func (gm GameMode) getControls() string {
+func (gm *GameMode) getControls() string {
 	return " | 1-7: select cards, Enter/P: play, D: discard, C: clear, R: resort, H: help, Q: quit"
 }
 
 type GameHelpMode struct{}
 
 // renderHelp renders the help screen
-func (gm GameHelpMode) renderContent(m TUIModel) string {
+func (gm GameHelpMode) renderContent(m *TUIModel) string {
 	helpStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("33")).

--- a/internal/ui/tui_shop.go
+++ b/internal/ui/tui_shop.go
@@ -16,7 +16,7 @@ type ShoppingMode struct {
 	consecutiveEnters int
 }
 
-func (ms ShoppingMode) renderContent(m TUIModel) string {
+func (ms *ShoppingMode) renderContent(m *TUIModel) string {
 	gameInfo := fmt.Sprintf("%s Ante %d - %s✅\n", "🏪", m.gameState.Ante, m.gameState.Blind) +
 		fmt.Sprintf("🎴 Hands: %d | 🗑️ Discards: %d | 💰 Money: $%d | 🎲 Reroll: $%d",
 			m.gameState.Hands, m.gameState.Discards, m.gameState.Money, m.shopInfo.RerollCost)
@@ -27,7 +27,7 @@ func (ms ShoppingMode) renderContent(m TUIModel) string {
 	var jokerViews []string
 
 	for idx, joker := range m.shopInfo.Items {
-		jokerStr := renderJoker(m, joker)
+		jokerStr := renderJoker(*m, joker)
 
 		posNumStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("244"))
@@ -51,7 +51,7 @@ func (ms ShoppingMode) renderContent(m TUIModel) string {
 	)
 }
 
-func (gm ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
+func (gm *ShoppingMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, tea.Cmd) {
 	// Update last activity time on any key press
 	m.lastActivity = time.Now()
 
@@ -113,11 +113,11 @@ func renderJoker(m TUIModel, joker game.ShopItemData) string {
 	return jokerStr
 }
 
-func (gm ShoppingMode) toggleHelp() Mode {
+func (gm *ShoppingMode) toggleHelp() Mode {
 	return &ShopHelpMode{}
 }
 
-func (gm ShoppingMode) getControls() string {
+func (gm *ShoppingMode) getControls() string {
 	// TODO I do think we'll need the game state to know how many shop items are available
 	// but for now hardcode to 4
 	return " | 1-4: select item, Enter (with selected): purchase, Enter (without selected): exit, C: clear, R: reroll, H: help, ESC: exit, Q: quit"
@@ -126,7 +126,7 @@ func (gm ShoppingMode) getControls() string {
 type ShopHelpMode struct{}
 
 // renderHelp renders the help screen
-func (gm ShopHelpMode) renderContent(m TUIModel) string {
+func (gm ShopHelpMode) renderContent(m *TUIModel) string {
 	return "you're in the shop, brother"
 }
 

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -29,7 +29,7 @@ func TestToggleCardSelection(t *testing.T) {
 
 // TestHelpToggle ensures that pressing 'h' toggles help mode on and off.
 func TestHelpToggle(t *testing.T) {
-	m := TUIModel{mode: GameMode{}}
+	m := TUIModel{mode: &GameMode{}}
 
 	model, _ := m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	m = model.(TUIModel)
@@ -60,7 +60,7 @@ func TestShoppingModeActions(t *testing.T) {
 	m := TUIModel{
 		gameState:            game.GameStateChangedEvent{Money: 10},
 		shopInfo:             &game.ShopOpenedEvent{Money: 10, RerollCost: 5, Items: []game.ShopItemData{{Name: "J1", Cost: 5, Description: "", CanAfford: true}}},
-		mode:                 ShoppingMode{selectedItem: &selected},
+		mode:                 &ShoppingMode{selectedItem: &selected},
 		actionRequestPending: &PlayerActionRequest{ResponseChan: respChan},
 	}
 
@@ -76,7 +76,7 @@ func TestShoppingModeActions(t *testing.T) {
 	mPtr := model.(*TUIModel)
 	m = *mPtr
 	m.actionRequestPending = &PlayerActionRequest{ResponseChan: respChan}
-	m.mode = ShoppingMode{}
+	m.mode = &ShoppingMode{}
 	model, _ = m.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	resp = <-respChan
 	if resp.Action != game.PlayerActionReroll {


### PR DESCRIPTION
## Summary
- switch Mode interface to operate on `*TUIModel`
- store `GameMode` and `ShoppingMode` as pointers
- use pointer receivers for game and shop modes to persist state across key presses

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899593ce0b0832ca919742a4d6ddd8f