### PR TITLE
fix: prevent TUI nil mode panic

### DIFF
--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -371,7 +371,11 @@ func (m TUIModel) View() string {
 	timeStr := time.Now().Format("15:04:05")
 	timeoutRemaining := m.timeoutDuration - time.Since(m.lastActivity)
 	timeoutStr := fmt.Sprintf("%.0fs", timeoutRemaining.Seconds())
-	controls := "⏰ " + timeStr + " | Timeout: " + timeoutStr + m.mode.getControls()
+	mode := m.mode
+	if mode == nil {
+		mode = GameMode{}
+	}
+	controls := "⏰ " + timeStr + " | Timeout: " + timeoutStr + mode.getControls()
 	bottomBar := bottomBarStyle.
 		Width(m.width).
 		Render(controls)
@@ -384,7 +388,7 @@ func (m TUIModel) View() string {
 	// 	m.mode = m.mode.toggleHelp()
 	// }
 
-	content = m.mode.renderContent(m)
+	content = mode.renderContent(m)
 
 	renderedContent := mainContentStyle.
 		Width(m.width).
@@ -570,6 +574,7 @@ func RunTUI() error {
 		lastActivity:    time.Now(),
 		currentTime:     time.Now(),
 		selectedCards:   []int{},
+		mode:            GameMode{},
 	}
 	// model.Init()
 

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -83,3 +83,16 @@ func TestShoppingModeActions(t *testing.T) {
 		t.Fatalf("unexpected reroll response: %+v", resp)
 	}
 }
+
+// TestViewHandlesNilMode ensures View does not panic when mode is unset.
+func TestViewHandlesNilMode(t *testing.T) {
+	m := TUIModel{width: 10, height: 10}
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("View panicked: %v", r)
+			}
+		}()
+		_ = m.View()
+	}()
+}


### PR DESCRIPTION
## Summary
- initialize `TUIModel` with a default `GameMode` to avoid nil deref
- gracefully fallback to `GameMode` when rendering with a nil mode
- test that `View` does not panic when mode is unset

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689959bb2ed0832c945137452a746b8b