### PR TITLE
feat: confirm shop exit with double enter

### DIFF
--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -266,7 +266,7 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		shopCopy := event
 		m.shopInfo = &shopCopy
 		m.gameState.Money = event.Money
-		m.mode = ShoppingMode{}
+		m.mode = &ShoppingMode{}
 		m.setStatusMessage("🛍️ Welcome to the Shop!")
 		m.logEvent("Entered shop")
 		return m, nil


### PR DESCRIPTION
## Summary
- require pressing Enter twice without a selection to exit shop
- preserve shopping mode state using pointer and reset consecutive enters appropriately
- update controls text and tests for new exit confirmation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a596a5410832c9d6f6901b098f52d