### PR TITLE
Add JSON-based game loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ go run . -seed 42
 
 # TUI mode with seed
 go run . -tui -seed 42
+
+# Load a saved game
+go run . -load save.json
+```
+
+The JSON file should contain:
+
+```json
+{
+  "save_version": 1,
+  "seed": 42,
+  "current_ante": 1,
+  "current_blind": "Small Blind",
+  "current_money": 4,
+  "current_jokers": []
+}
 ```
 
 ### TUI Mode Timeout

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -313,3 +313,8 @@ The YAML joker system transforms gameplay from simple optimization to complex st
 - **A/B Testing**: Easy to compare different joker power levels
 
 This implementation brings Balatro CLI significantly closer to the authentic Balatro experience by adding both the crucial economic layer AND the strategic depth of configurable joker synergies that make the game endlessly replayable.
+
+## 💾 Save & Load
+
+- **Load from JSON**: Resume a run using `-load <file>`
+- **Save format**: JSON with `save_version`, `seed`, `current_ante`, `current_blind`, `current_money`, and `current_jokers`

--- a/internal/game/jokers.go
+++ b/internal/game/jokers.go
@@ -243,6 +243,16 @@ func GetAvailableJokers() []Joker {
 	return jokers
 }
 
+// GetJokerByName returns a Joker by its name if it exists
+func GetJokerByName(name string) (Joker, bool) {
+	for _, config := range jokerConfigs {
+		if config.Name == name {
+			return createJokerFromConfig(config), true
+		}
+	}
+	return Joker{}, false
+}
+
 // GetGoldenJoker returns The Golden Joker (for backward compatibility)
 func GetGoldenJoker() Joker {
 	for _, config := range jokerConfigs {

--- a/internal/game/save.go
+++ b/internal/game/save.go
@@ -1,0 +1,71 @@
+package game
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+type saveFile struct {
+	SaveVersion   int      `json:"save_version"`
+	Seed          int64    `json:"seed"`
+	CurrentAnte   int      `json:"current_ante"`
+	CurrentBlind  string   `json:"current_blind"`
+	CurrentMoney  int      `json:"current_money"`
+	CurrentJokers []string `json:"current_jokers"`
+}
+
+func parseBlindType(name string) (BlindType, error) {
+	switch name {
+	case SmallBlind.String():
+		return SmallBlind, nil
+	case BigBlind.String():
+		return BigBlind, nil
+	case BossBlind.String():
+		return BossBlind, nil
+	default:
+		return SmallBlind, fmt.Errorf("unknown blind type %q", name)
+	}
+}
+
+// LoadGameFromFile creates a Game using state from a JSON save file
+func LoadGameFromFile(path string, handler EventHandler) (*Game, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var save saveFile
+	if err := json.Unmarshal(data, &save); err != nil {
+		return nil, err
+	}
+
+	if save.SaveVersion != 1 {
+		return nil, fmt.Errorf("unsupported save version: %d", save.SaveVersion)
+	}
+
+	if save.Seed != 0 {
+		SetSeed(save.Seed)
+	}
+
+	g := NewGame(handler)
+	g.currentAnte = save.CurrentAnte
+	bt, err := parseBlindType(save.CurrentBlind)
+	if err != nil {
+		return nil, err
+	}
+	g.currentBlind = bt
+	g.money = save.CurrentMoney
+
+	g.jokers = []Joker{}
+	for _, name := range save.CurrentJokers {
+		if joker, ok := GetJokerByName(name); ok {
+			g.jokers = append(g.jokers, joker)
+		} else {
+			return nil, fmt.Errorf("unknown joker: %s", name)
+		}
+	}
+
+	g.currentTarget = GetAnteRequirement(g.currentAnte, g.currentBlind)
+	return g, nil
+}

--- a/internal/game/save_load_test.go
+++ b/internal/game/save_load_test.go
@@ -1,0 +1,55 @@
+package game
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestLoadGameFromFile(t *testing.T) {
+	save := saveFile{
+		SaveVersion:   1,
+		Seed:          123,
+		CurrentAnte:   2,
+		CurrentBlind:  BigBlind.String(),
+		CurrentMoney:  10,
+		CurrentJokers: []string{"The Golden Joker"},
+	}
+
+	tmp, err := os.CreateTemp("", "save*.json")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if err := json.NewEncoder(tmp).Encode(save); err != nil {
+		t.Fatalf("encoding save: %v", err)
+	}
+	tmp.Close()
+
+	g, err := LoadGameFromFile(tmp.Name(), NewLoggerEventHandler())
+	if err != nil {
+		t.Fatalf("LoadGameFromFile returned error: %v", err)
+	}
+
+	if g.currentAnte != 2 {
+		t.Errorf("currentAnte = %d, want 2", g.currentAnte)
+	}
+	if g.currentBlind != BigBlind {
+		t.Errorf("currentBlind = %v, want %v", g.currentBlind, BigBlind)
+	}
+	if g.money != 10 {
+		t.Errorf("money = %d, want 10", g.money)
+	}
+	if len(g.jokers) != 1 || g.jokers[0].Name != "The Golden Joker" {
+		t.Fatalf("jokers = %#v, want The Golden Joker", g.jokers)
+	}
+
+	SetSeed(123)
+	expected := NewGame(NewLoggerEventHandler())
+	for i, card := range expected.deck {
+		if g.deck[i] != card {
+			t.Fatalf("deck differs at %d", i)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -11,17 +11,15 @@ import (
 func main() {
 	// Parse command line flags
 	seed := flag.Int64("seed", 0, "Set random seed for reproducible gameplay (0 for random)")
+	load := flag.String("load", "", "Load game state from JSON file")
 	tui := flag.Bool("tui", false, "Run in TUI mode instead of console mode")
 	flag.Parse()
 
-	// Set seed if provided
-	if *seed != 0 {
-		game.SetSeed(*seed)
-		fmt.Printf("Using seed: %d\n", *seed)
-	}
-
 	// Run in TUI mode or console mode
 	if *tui {
+		if *load != "" {
+			fmt.Println("Load flag currently only supported in console mode")
+		}
 		if err := ui.RunTUI(); err != nil {
 			fmt.Printf("Error running TUI: %v\n", err)
 		}
@@ -29,8 +27,27 @@ func main() {
 		// Create event handler for console mode
 		eventHandler := game.NewLoggerEventHandler()
 
-		// Create and run the game
-		g := game.NewGame(eventHandler)
+		var g *game.Game
+		var err error
+
+		if *load != "" {
+			g, err = game.LoadGameFromFile(*load, eventHandler)
+			if err != nil {
+				fmt.Printf("Error loading game: %v\n", err)
+				return
+			}
+			if *seed != 0 {
+				fmt.Println("Seed flag ignored when loading game")
+			}
+		} else {
+			if *seed != 0 {
+				game.SetSeed(*seed)
+				fmt.Printf("Using seed: %d\n", *seed)
+			}
+			g = game.NewGame(eventHandler)
+		}
+
+		// Run the game
 		g.Run()
 	}
 }


### PR DESCRIPTION
## Summary
- add `-load` flag to start a game from a JSON save file
- support restoring ante, blind, money, jokers and seed
- document save format and loading instructions

## Testing
- `go fmt .`
- `go fmt ./internal/game`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a5c1c0fc8832cb7d3c901d625e0ac