### PR TITLE
Add card-based joker matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,13 @@ jokers:
     effect: "AddMoney"
     effect_magnitude: 4
     hand_matching_rule: "None"
+    card_matching_rule: "None"
     description: "Earn $4 at the end of each Blind"
 ```
 - **YAML format** for complex joker configurations
 - **Effect types**: `AddMoney`, `AddChips`, `AddMult`
 - **Hand matching**: Trigger jokers based on hand types (pairs, straights, etc.)
+- **Card matching**: Award bonuses per matching card (Aces, Spades, face cards, etc.)
 - **Runtime loading** with fallback to defaults
 
 ### Making Balance Changes

--- a/docs/JOKER_CONFIG.md
+++ b/docs/JOKER_CONFIG.md
@@ -13,7 +13,8 @@ jokers:
     rarity: "Common"            # Currently unused, for future expansion  
     effect: "AddChips"          # Effect type
     effect_magnitude: 30        # Strength of effect
-    hand_matching_rule: "ContainsPair"  # When to trigger
+    hand_matching_rule: "ContainsPair"  # When to trigger based on hand type
+    card_matching_rule: "IsAce"         # (Optional) bonus per matching card
     description: "Description shown in shop"
 ```
 
@@ -135,6 +136,31 @@ Triggers only on Royal Flush.
 
 ```yaml
 hand_matching_rule: "ContainsRoyalFlush"
+```
+
+## 🂠 Card Matching Rules
+
+Card matching rules award the joker's effect magnitude for each card in the played hand that matches the rule. When a `card_matching_rule` is present, the `hand_matching_rule` is ignored for scoring purposes.
+
+### `IsAce`
+Triggers for each Ace in the played hand.
+
+```yaml
+card_matching_rule: "IsAce"
+```
+
+### `IsSpade`
+Triggers for each Spade in the played hand.
+
+```yaml
+card_matching_rule: "IsSpade"
+```
+
+### `IsFace`
+Triggers for each face card (J, Q, K).
+
+```yaml
+card_matching_rule: "IsFace"
 ```
 
 ## 📊 Example Configurations

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -294,7 +294,7 @@ func (g *Game) handlePlayAction(params []string) {
 	evaluator, _, cardValues, baseScore := EvaluateHand(hand)
 
 	// Calculate joker bonuses
-	jokerChips, jokerMult := CalculateJokerHandBonus(g.jokers, evaluator.Name())
+	jokerChips, jokerMult := CalculateJokerHandBonus(g.jokers, evaluator.Name(), selectedCards)
 
 	// Apply joker bonuses to final score
 	finalBaseScore := baseScore + jokerChips

--- a/internal/game/jokers.yaml
+++ b/internal/game/jokers.yaml
@@ -118,3 +118,11 @@ jokers:
     effect_magnitude: 30
     hand_matching_rule: "ContainsFourOfAKind"
     description: "+30 Mult if played hand contains Four of a Kind"
+
+  - name: "Ace in the Hole"
+    value: 8
+    rarity: "Common"
+    effect: "AddChips"
+    effect_magnitude: 20
+    card_matching_rule: "IsAce"
+    description: "+20 Chips for each Ace played"

--- a/internal/game/jokers_test.go
+++ b/internal/game/jokers_test.go
@@ -18,19 +18,37 @@ func TestCalculateJokerHandBonus(t *testing.T) {
 	multCfg := JokerConfig{Name: "Mult", Effect: AddMult, EffectMagnitude: 5, HandMatchingRule: ContainsPair}
 	multJoker := createJokerFromConfig(multCfg)
 
-	chips, mult := CalculateJokerHandBonus([]Joker{chipJoker}, "Pair")
+	chips, mult := CalculateJokerHandBonus([]Joker{chipJoker}, "Pair", []Card{})
 	if chips != 30 || mult != 0 {
 		t.Fatalf("expected 30 chips bonus, got chips=%d mult=%d", chips, mult)
 	}
 
-	chips, mult = CalculateJokerHandBonus([]Joker{multJoker}, "Pair")
+	chips, mult = CalculateJokerHandBonus([]Joker{multJoker}, "Pair", []Card{})
 	if chips != 0 || mult != 5 {
 		t.Fatalf("expected mult bonus 5, got chips=%d mult=%d", chips, mult)
 	}
 
 	// Non-matching hand should yield no bonus
-	chips, mult = CalculateJokerHandBonus([]Joker{chipJoker}, "High Card")
+	chips, mult = CalculateJokerHandBonus([]Joker{chipJoker}, "High Card", []Card{})
 	if chips != 0 || mult != 0 {
 		t.Fatalf("expected no bonus for non-matching hand, got chips=%d mult=%d", chips, mult)
+	}
+}
+
+// TestCardMatchingRule verifies bonuses based on individual card matches.
+func TestCardMatchingRule(t *testing.T) {
+	cfg := JokerConfig{Name: "Ace Bonus", Effect: AddChips, EffectMagnitude: 10, CardMatchingRule: CardIsAce}
+	joker := createJokerFromConfig(cfg)
+
+	hand := []Card{{Rank: Ace, Suit: Hearts}, {Rank: Ace, Suit: Spades}, {Rank: Two, Suit: Clubs}}
+	chips, mult := CalculateJokerHandBonus([]Joker{joker}, "High Card", hand)
+	if chips != 20 || mult != 0 {
+		t.Fatalf("expected 20 chips bonus, got chips=%d mult=%d", chips, mult)
+	}
+
+	hand = []Card{{Rank: Two, Suit: Clubs}}
+	chips, mult = CalculateJokerHandBonus([]Joker{joker}, "High Card", hand)
+	if chips != 0 || mult != 0 {
+		t.Fatalf("expected no bonus without matching cards, got chips=%d mult=%d", chips, mult)
 	}
 }


### PR DESCRIPTION
## Summary
- allow jokers to award bonuses for individual cards (aces, spades, faces)
- wire card-aware joker scoring into gameplay and tests
- document `card_matching_rule` and add example joker

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689aab7586c4832c9f35b8d70015c3cd