### PR TITLE
Add composite joker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,24 @@ jokers:
 - **Hand matching**: Trigger jokers based on hand types (pairs, straights, etc.)
 - **Runtime loading** with fallback to defaults
 
+Composite jokers can list multiple effects:
+
+```yaml
+- name: "Combo"
+  value: 8
+  description: "Earn $2 and +10 chips/+3 mult for pairs"
+  effects:
+    - effect: "AddMoney"
+      effect_magnitude: 2
+      hand_matching_rule: "None"
+    - effect: "AddChips"
+      effect_magnitude: 10
+      hand_matching_rule: "ContainsPair"
+    - effect: "AddMult"
+      effect_magnitude: 3
+      hand_matching_rule: "ContainsPair"
+```
+
 ### Making Balance Changes
 1. **Edit CSV/YAML files** with any text editor
 2. **Run the game** - changes load automatically

--- a/docs/JOKER_CONFIG.md
+++ b/docs/JOKER_CONFIG.md
@@ -10,11 +10,26 @@ This document explains how to configure jokers in Balatro CLI using the YAML-bas
 jokers:
   - name: "Joker Name"
     value: 6                    # Price in shop
-    rarity: "Common"            # Currently unused, for future expansion  
+    rarity: "Common"            # Currently unused, for future expansion
     effect: "AddChips"          # Effect type
     effect_magnitude: 30        # Strength of effect
     hand_matching_rule: "ContainsPair"  # When to trigger
     description: "Description shown in shop"
+
+  # Composite jokers can specify multiple effects
+  - name: "Combo"
+    value: 8
+    description: "Earn $2 and +10 chips/+3 mult for pairs"
+    effects:
+      - effect: "AddMoney"
+        effect_magnitude: 2
+        hand_matching_rule: "None"
+      - effect: "AddChips"
+        effect_magnitude: 10
+        hand_matching_rule: "ContainsPair"
+      - effect: "AddMult"
+        effect_magnitude: 3
+        hand_matching_rule: "ContainsPair"
 ```
 
 ## 🎭 Effect Types

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -87,8 +87,10 @@ type Game struct {
 func (g *Game) handSize() int {
 	size := InitialCards
 	for _, j := range g.jokers {
-		if j.Effect == AddHandSize {
-			size += j.EffectMagnitude
+		for _, e := range j.Effects {
+			if e.Effect == AddHandSize {
+				size += e.EffectMagnitude
+			}
 		}
 	}
 	return size
@@ -98,8 +100,10 @@ func (g *Game) handSize() int {
 func (g *Game) maxDiscards() int {
 	max := MaxDiscards
 	for _, j := range g.jokers {
-		if j.Effect == AddDiscards {
-			max += j.EffectMagnitude
+		for _, e := range j.Effects {
+			if e.Effect == AddDiscards {
+				max += e.EffectMagnitude
+			}
 		}
 	}
 	return max

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -153,7 +153,7 @@ func TestShowShopWithItems(t *testing.T) {
 // TestHandSizeWithJoker verifies that a joker can increase the hand size.
 func TestHandSizeWithJoker(t *testing.T) {
 	g := &Game{
-		jokers: []Joker{{Effect: AddHandSize, EffectMagnitude: 2}},
+		jokers: []Joker{{Effects: []JokerEffectConfig{{Effect: AddHandSize, EffectMagnitude: 2}}}},
 	}
 	if got := g.handSize(); got != InitialCards+2 {
 		t.Fatalf("expected hand size %d, got %d", InitialCards+2, got)
@@ -168,7 +168,7 @@ func TestDiscardLimitWithJoker(t *testing.T) {
 		deck:         deck,
 		deckIndex:    InitialCards,
 		playerCards:  deck[:InitialCards],
-		jokers:       []Joker{{Effect: AddDiscards, EffectMagnitude: 2}},
+		jokers:       []Joker{{Effects: []JokerEffectConfig{{Effect: AddDiscards, EffectMagnitude: 2}}}},
 		eventEmitter: NewEventEmitter(),
 	}
 	g.eventEmitter.SetEventHandler(handler)

--- a/internal/game/jokers_test.go
+++ b/internal/game/jokers_test.go
@@ -34,3 +34,26 @@ func TestCalculateJokerHandBonus(t *testing.T) {
 		t.Fatalf("expected no bonus for non-matching hand, got chips=%d mult=%d", chips, mult)
 	}
 }
+
+// TestCompositeJoker verifies that a joker can apply multiple effects.
+func TestCompositeJoker(t *testing.T) {
+	cfg := JokerConfig{
+		Name: "Combo",
+		Effects: []JokerEffectConfig{
+			{Effect: AddChips, EffectMagnitude: 10, HandMatchingRule: ContainsPair},
+			{Effect: AddMult, EffectMagnitude: 3, HandMatchingRule: ContainsPair},
+			{Effect: AddMoney, EffectMagnitude: 2, HandMatchingRule: None},
+		},
+	}
+	j := createJokerFromConfig(cfg)
+
+	chips, mult := CalculateJokerHandBonus([]Joker{j}, "Pair")
+	if chips != 10 || mult != 3 {
+		t.Fatalf("expected chips=10 mult=3, got chips=%d mult=%d", chips, mult)
+	}
+
+	reward := CalculateJokerRewards([]Joker{j})
+	if reward != 2 {
+		t.Fatalf("expected money reward 2, got %d", reward)
+	}
+}


### PR DESCRIPTION
## Summary
- allow jokers to combine multiple effect definitions
- include composite effects when calculating hand size and discards
- document new `effects` list for configuring composite jokers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689aab10c828832c988c06d88898c86d