### PR TITLE
Add auto-saving on graceful exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ go run . -tui -seed 42
 go run . -load save.json
 ```
 
+# Automatic saving
+When you quit the game or it times out, the current state is saved to a timestamped JSON file like `2025-08-11T16:38:12Z.json`. The file will not be written if the process is interrupted with `Ctrl+C`.
+
 The JSON file should contain:
 
 ```json

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -317,4 +317,5 @@ This implementation brings Balatro CLI significantly closer to the authentic Bal
 ## 💾 Save & Load
 
 - **Load from JSON**: Resume a run using `-load <file>`
+- **Auto-save**: Game state written to timestamped JSON when quitting or timing out
 - **Save format**: JSON with `save_version`, `seed`, `current_ante`, `current_blind`, `current_money`, and `current_jokers`

--- a/internal/game/deck.go
+++ b/internal/game/deck.go
@@ -9,14 +9,22 @@ import (
 
 // Global random source for consistent seeding
 var rng *rand.Rand
+var currentSeed int64
 
 func init() {
-	rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+	currentSeed = time.Now().UnixNano()
+	rng = rand.New(rand.NewSource(currentSeed))
 }
 
 // SetSeed allows setting a specific seed for deterministic behavior (useful for testing)
 func SetSeed(seed int64) {
+	currentSeed = seed
 	rng = rand.New(rand.NewSource(seed))
+}
+
+// GetSeed returns the current random seed
+func GetSeed() int64 {
+	return currentSeed
 }
 
 type Suit int

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -150,6 +150,7 @@ func (g *Game) Run() {
 	g.eventEmitter.EmitGameStarted()
 
 	gameRunning := true
+	shouldSave := false
 	for gameRunning && g.currentAnte <= MaxAntes {
 		for g.handsPlayed < MaxHands && g.totalScore < g.currentTarget {
 			// Update display mapping and emit current state
@@ -161,6 +162,7 @@ func (g *Game) Run() {
 			action, params, quit := g.eventEmitter.handler.GetPlayerAction(g.discardsUsed < MaxDiscards)
 			if quit {
 				g.eventEmitter.EmitInfo("Thanks for playing!")
+				shouldSave = true
 				gameRunning = false
 				break
 			}
@@ -194,6 +196,14 @@ func (g *Game) Run() {
 
 	if gameRunning && g.currentAnte > MaxAntes {
 		g.eventEmitter.EmitEvent(VictoryEvent{})
+	}
+
+	if shouldSave {
+		if filename, err := g.Save(); err != nil {
+			g.eventEmitter.EmitError(fmt.Sprintf("Failed to save game: %v", err))
+		} else {
+			g.eventEmitter.EmitInfo(fmt.Sprintf("Game saved to %s", filename))
+		}
 	}
 
 	g.eventEmitter.handler.Close()

--- a/internal/game/save_load_test.go
+++ b/internal/game/save_load_test.go
@@ -53,3 +53,40 @@ func TestLoadGameFromFile(t *testing.T) {
 		}
 	}
 }
+
+func TestSaveGameToFile(t *testing.T) {
+	SetSeed(456)
+	g := NewGame(NewLoggerEventHandler())
+
+	filename, err := g.Save()
+	if err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+	defer os.Remove(filename)
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("reading save file: %v", err)
+	}
+
+	var save saveFile
+	if err := json.Unmarshal(data, &save); err != nil {
+		t.Fatalf("unmarshal save: %v", err)
+	}
+
+	if save.Seed != 456 {
+		t.Errorf("seed = %d, want 456", save.Seed)
+	}
+	if save.CurrentAnte != g.currentAnte {
+		t.Errorf("ante = %d, want %d", save.CurrentAnte, g.currentAnte)
+	}
+	if save.CurrentBlind != g.currentBlind.String() {
+		t.Errorf("blind = %s, want %s", save.CurrentBlind, g.currentBlind.String())
+	}
+	if save.CurrentMoney != g.money {
+		t.Errorf("money = %d, want %d", save.CurrentMoney, g.money)
+	}
+	if len(save.CurrentJokers) != len(g.jokers) {
+		t.Errorf("jokers = %v, want %v", save.CurrentJokers, g.jokers)
+	}
+}


### PR DESCRIPTION
## Summary
- Track and expose the current RNG seed for reproducible saves
- Save game state to timestamped JSON files and trigger on quit or timeout
- Document automatic saving behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a62fcd0e4832cb17ef0c377e5add8