### PR TITLE
Fix shop exit after purchase

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -693,6 +693,7 @@ func (g *Game) showShopWithItems(availableJokers []Joker, shopItems []Joker) {
 		}
 
 		if action == PlayerActionExitShop {
+			g.eventEmitter.EmitEvent(ShopClosedEvent{})
 			return
 		} else if action == PlayerActionReroll {
 			if g.money >= g.rerollCost {

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -133,13 +133,15 @@ func TestShowShopWithItems(t *testing.T) {
 	if len(g.jokers) != 1 || g.jokers[0].Name != "J1" {
 		t.Fatalf("expected to own J1 after purchase")
 	}
-	opened, purchased := false, false
+	opened, purchased, closed := false, false, false
 	for _, e := range handler.events {
 		switch e.(type) {
 		case ShopOpenedEvent:
 			opened = true
 		case ShopItemPurchasedEvent:
 			purchased = true
+		case ShopClosedEvent:
+			closed = true
 		}
 	}
 	if !opened {
@@ -147,6 +149,9 @@ func TestShowShopWithItems(t *testing.T) {
 	}
 	if !purchased {
 		t.Fatalf("expected ShopItemPurchasedEvent to be emitted")
+	}
+	if !closed {
+		t.Fatalf("expected ShopClosedEvent to be emitted on exit")
 	}
 }
 


### PR DESCRIPTION
## Summary
- emit `ShopClosedEvent` when exiting the shop after buying an item
- test shop exit to ensure `ShopClosedEvent` is fired

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689aae3fb7bc832c829345524b909741