### PR TITLE
Add replay card joker effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ jokers:
     description: "Earn $4 at the end of each Blind"
 ```
 - **YAML format** for complex joker configurations
-- **Effect types**: `AddMoney`, `AddChips`, `AddMult`
+- **Effect types**: `AddMoney`, `AddChips`, `AddMult`, `ReplayCard`
 - **Hand matching**: Trigger jokers based on hand types (pairs, straights, etc.)
 - **Card matching**: Award bonuses per matching card (Aces, Spades, face cards, etc.)
 - **Runtime loading** with fallback to defaults

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -112,6 +112,10 @@ type Joker struct {
 - **Linear Logic** ($7): +20 mult if hand contains a Straight
 - **Effect**: Increases final multiplier for explosive scoring
 
+#### ReplayCard Jokers
+- **Face Dancer** ($7): Face cards are scored twice
+- **Effect**: Replays matching cards, doubling their value and bonuses
+
 ### Hand Matching Rules
 - **ContainsPair**: Triggers on Pair, Two Pair, Full House, Four of a Kind
 - **ContainsTwoPair**: Triggers on Two Pair, Full House

--- a/docs/JOKER_CONFIG.md
+++ b/docs/JOKER_CONFIG.md
@@ -54,6 +54,19 @@ Adds multiplier when playing matching hands.
 
 **Score Calculation**: `(base_score + card_values) × (base_mult + joker_mult)`
 
+### `ReplayCard`
+Replays matching cards so they're scored twice.
+
+```yaml
+- name: "Face Dancer"
+  effect: "ReplayCard"
+  effect_magnitude: 0
+  card_matching_rule: "IsFace"
+  description: "Face cards are scored twice"
+```
+
+**Score Calculation**: Matching cards add their value again and retrigger card-based bonuses.
+
 ## 🃏 Hand Matching Rules
 
 ### `None`

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -289,12 +289,16 @@ func (g *Game) handlePlayAction(params []string) {
 		return
 	}
 
+	// Apply replay effects for matching cards
+	cardsForJokers, extraCardValue := ApplyReplayCardEffects(g.jokers, selectedCards)
+
 	// Evaluate the hand
 	hand := Hand{Cards: selectedCards}
 	evaluator, _, cardValues, baseScore := EvaluateHand(hand)
+	cardValues += extraCardValue
 
-	// Calculate joker bonuses
-	jokerChips, jokerMult := CalculateJokerHandBonus(g.jokers, evaluator.Name(), selectedCards)
+	// Calculate joker bonuses using cards including replays
+	jokerChips, jokerMult := CalculateJokerHandBonus(g.jokers, evaluator.Name(), cardsForJokers)
 
 	// Apply joker bonuses to final score
 	finalBaseScore := baseScore + jokerChips

--- a/internal/game/jokers.yaml
+++ b/internal/game/jokers.yaml
@@ -126,3 +126,11 @@ jokers:
     effect_magnitude: 20
     card_matching_rule: "IsAce"
     description: "+20 Chips for each Ace played"
+
+  - name: "Face Dancer"
+    value: 7
+    rarity: "Common"
+    effect: "ReplayCard"
+    effect_magnitude: 0
+    card_matching_rule: "IsFace"
+    description: "Face cards are scored twice"

--- a/internal/game/jokers_test.go
+++ b/internal/game/jokers_test.go
@@ -52,3 +52,26 @@ func TestCardMatchingRule(t *testing.T) {
 		t.Fatalf("expected no bonus without matching cards, got chips=%d mult=%d", chips, mult)
 	}
 }
+
+// TestReplayFaceCards verifies that ReplayCard jokers process matching cards twice.
+func TestReplayFaceCards(t *testing.T) {
+	replayCfg := JokerConfig{Name: "Face Dancer", Effect: ReplayCard, CardMatchingRule: CardIsFace}
+	replayJoker := createJokerFromConfig(replayCfg)
+	bonusCfg := JokerConfig{Name: "Face Bonus", Effect: AddChips, EffectMagnitude: 10, CardMatchingRule: CardIsFace}
+	bonusJoker := createJokerFromConfig(bonusCfg)
+
+	cards := []Card{{Rank: Jack, Suit: Hearts}, {Rank: Five, Suit: Clubs}}
+	hand := Hand{Cards: cards}
+	evaluator, _, cardValues, baseScore := EvaluateHand(hand)
+
+	cardsForJokers, extraValue := ApplyReplayCardEffects([]Joker{replayJoker, bonusJoker}, cards)
+	cardValues += extraValue
+	chips, mult := CalculateJokerHandBonus([]Joker{replayJoker, bonusJoker}, evaluator.Name(), cardsForJokers)
+	finalBase := baseScore + chips
+	finalMult := evaluator.Multiplier() + mult
+	finalScore := (finalBase + cardValues) * finalMult
+
+	if finalScore != 50 {
+		t.Fatalf("expected final score 50, got %d", finalScore)
+	}
+}


### PR DESCRIPTION
## Summary
- add `ReplayCard` effect for jokers and helper to apply it
- handle replayed cards in scoring and provide `Face Dancer` config
- document replay card jokers and test face-card replay

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689aad2fa344832c96082c710785084e