### PR TITLE
Fix config file lookups so CSV/YAML configs load

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ jokers:
 - **Card matching**: Award bonuses per matching card (Aces, Spades, face cards, etc.)
 - **Runtime loading** with fallback to defaults
 
+The game searches upward from the current working directory to locate
+these configuration files, so it can run from any subdirectory of the
+repository.
+
 ### Making Balance Changes
 1. **Edit CSV/YAML files** with any text editor
 2. **Run the game** - changes load automatically

--- a/internal/game/config.go
+++ b/internal/game/config.go
@@ -3,7 +3,6 @@ package game
 import (
 	"encoding/csv"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 )
@@ -54,7 +53,7 @@ func LoadConfig() error {
 
 // loadAnteRequirements loads ante requirements from CSV file
 func (c *Config) loadAnteRequirements() error {
-	file, err := os.Open(filepath.Join("internal", "game", "ante_requirements.csv"))
+	file, err := openGameFile(filepath.Join("internal", "game", "ante_requirements.csv"))
 	if err != nil {
 		return err
 	}
@@ -104,7 +103,7 @@ func (c *Config) loadAnteRequirements() error {
 
 // loadHandScores loads hand scores from CSV file
 func (c *Config) loadHandScores() error {
-	file, err := os.Open(filepath.Join("internal", "game", "hand_scores.csv"))
+	file, err := openGameFile(filepath.Join("internal", "game", "hand_scores.csv"))
 	if err != nil {
 		return err
 	}

--- a/internal/game/filepaths.go
+++ b/internal/game/filepaths.go
@@ -1,0 +1,36 @@
+package game
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// openGameFile searches for a file by walking up the directory tree
+// starting from the current working directory. It returns the first
+// matching file found or an error if the file cannot be located.
+func openGameFile(relPath string) (*os.File, error) {
+	// Try relative to the current working directory first
+	if f, err := os.Open(relPath); err == nil {
+		return f, nil
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		tryPath := filepath.Join(dir, relPath)
+		if f, err := os.Open(tryPath); err == nil {
+			return f, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	return nil, fmt.Errorf("could not locate %s", relPath)
+}

--- a/internal/game/jokers.go
+++ b/internal/game/jokers.go
@@ -3,7 +3,6 @@ package game
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
@@ -91,7 +90,7 @@ func LoadJokerConfigs() error {
 
 // loadJokersFromYAML loads joker configurations from YAML file
 func loadJokersFromYAML() error {
-	file, err := os.Open(filepath.Join("internal", "game", "jokers.yaml"))
+	file, err := openGameFile(filepath.Join("internal", "game", "jokers.yaml"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- add helper that searches parent directories for CSV and YAML config files
- use helper to load ante requirements, hand scores, and jokers
- document automatic config lookup in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ab0537958832c9f7f2ae5972d630f