### PR TITLE
Render owned jokers in shop mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ type HandEvaluator interface {
 - **🎭 Blind Indicators**: Unique emojis for each blind type (🔸🔶💀)
 - **🎆 Celebrations**: Escalating victory animations with detailed reward breakdowns
 - **💰 Money Tracking**: Always-visible money counter in game status
-- **🏪 Shop Interface**: Clean shop display with affordability indicators
+- **🏪 Shop Interface**: Clean shop display with affordability indicators and current joker list
 - **📍 Clear Status**: Ante, blind type, money, and requirements always visible
 - **🎨 Colorful Output**: Rich terminal formatting for better UX
 - **🔀 Joker Reordering**: Adjust joker priority directly from the TUI

--- a/internal/ui/tui_shop.go
+++ b/internal/ui/tui_shop.go
@@ -44,10 +44,23 @@ func (ms ShoppingMode) renderContent(m TUIModel) string {
 
 	jokerDisplay := gameInfoStyle.Height(len(jokerViews)).Render(lipgloss.JoinVertical(lipgloss.Top, jokerViews...))
 
+	// Render currently owned jokers below the shop items
+	var ownedViews []string
+	if len(m.gameState.Jokers) == 0 {
+		ownedViews = append(ownedViews, "🃏 Jokers: None")
+	} else {
+		ownedViews = append(ownedViews, "🃏 Jokers:")
+		for _, j := range m.gameState.Jokers {
+			ownedViews = append(ownedViews, renderOwnedJoker(j))
+		}
+	}
+	ownedDisplay := gameInfoStyle.Height(len(ownedViews)).Render(lipgloss.JoinVertical(lipgloss.Left, ownedViews...))
+
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
 		gameInfoBox,
 		jokerDisplay,
+		ownedDisplay,
 	)
 }
 

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -204,5 +205,20 @@ func TestJokerReorder(t *testing.T) {
 
 	if m.gameState.Jokers[0].Name != "J2" {
 		t.Fatalf("expected J2 to move up, got %v", m.gameState.Jokers)
+	}
+}
+
+// TestShoppingModeRendersOwnedJokers ensures owned jokers are shown in shop mode.
+func TestShoppingModeRendersOwnedJokers(t *testing.T) {
+	m := TUIModel{
+		gameState: game.GameStateChangedEvent{
+			Jokers: []game.Joker{{Name: "J1", Description: "desc"}},
+		},
+		shopInfo: &game.ShopOpenedEvent{Money: 10, RerollCost: 5},
+	}
+	sm := ShoppingMode{}
+	output := sm.renderContent(m)
+	if !strings.Contains(output, "J1: desc") {
+		t.Fatalf("expected owned joker to be rendered, got %s", output)
 	}
 }


### PR DESCRIPTION
## Summary
- show a player's currently owned jokers in the shop interface
- document that the shop displays the current joker list
- test that owned jokers render when shopping

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b55deae68832c9e06857b5e8109cc