### PR TITLE
Add composite joker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,14 +194,16 @@ Two Pair,20,2
 jokers:
   - name: "The Golden Joker"
     value: 6
-    effect: "AddMoney"
-    effect_magnitude: 4
-    hand_matching_rule: "None"
-    card_matching_rule: "None"
     description: "Earn $4 at the end of each Blind"
+    effects:
+      - effect: "AddMoney"
+        effect_magnitude: 4
+        hand_matching_rule: "None"
+        card_matching_rule: "None"
 ```
 - **YAML format** for complex joker configurations
 - **Effect types**: `AddMoney`, `AddChips`, `AddMult`, `ReplayCard`
+- **Composite effects**: Combine multiple effects under `effects`
 - **Hand matching**: Trigger jokers based on hand types (pairs, straights, etc.)
 - **Card matching**: Award bonuses per matching card (Aces, Spades, face cards, etc.)
 - **Runtime loading** with fallback to defaults

--- a/docs/JOKER_CONFIG.md
+++ b/docs/JOKER_CONFIG.md
@@ -10,12 +10,13 @@ This document explains how to configure jokers in Balatro CLI using the YAML-bas
 jokers:
   - name: "Joker Name"
     value: 6                    # Price in shop
-    rarity: "Common"            # Currently unused, for future expansion  
-    effect: "AddChips"          # Effect type
-    effect_magnitude: 30        # Strength of effect
-    hand_matching_rule: "ContainsPair"  # When to trigger based on hand type
-    card_matching_rule: "IsAce"         # (Optional) bonus per matching card
+    rarity: "Common"            # Currently unused, for future expansion
     description: "Description shown in shop"
+    effects:
+      - effect: "AddChips"      # Effect type
+        effect_magnitude: 30    # Strength of effect
+        hand_matching_rule: "ContainsPair"  # When to trigger based on hand type
+        card_matching_rule: "IsAce"         # (Optional) bonus per matching card
 ```
 
 ## 🎭 Effect Types
@@ -66,6 +67,24 @@ Replays matching cards so they're scored twice.
 ```
 
 **Score Calculation**: Matching cards add their value again and retrigger card-based bonuses.
+
+## 🧩 Composite Jokers
+
+A joker can now include multiple effects via the `effects` array. Each entry follows the same structure as single-effect jokers.
+
+```yaml
+- name: "Combo"
+  value: 7
+  effects:
+    - effect: "AddChips"
+      effect_magnitude: 10
+      hand_matching_rule: "ContainsPair"
+    - effect: "AddMult"
+      effect_magnitude: 2
+      hand_matching_rule: "ContainsPair"
+```
+
+The joker above grants both +10 chips and +2 multiplier whenever the played hand contains a pair.
 
 ## 🃏 Hand Matching Rules
 

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -87,8 +87,10 @@ type Game struct {
 func (g *Game) handSize() int {
 	size := InitialCards
 	for _, j := range g.jokers {
-		if j.Effect == AddHandSize {
-			size += j.EffectMagnitude
+		for _, eff := range j.Effects {
+			if eff.Effect == AddHandSize {
+				size += eff.EffectMagnitude
+			}
 		}
 	}
 	return size
@@ -98,8 +100,10 @@ func (g *Game) handSize() int {
 func (g *Game) maxDiscards() int {
 	max := MaxDiscards
 	for _, j := range g.jokers {
-		if j.Effect == AddDiscards {
-			max += j.EffectMagnitude
+		for _, eff := range j.Effects {
+			if eff.Effect == AddDiscards {
+				max += eff.EffectMagnitude
+			}
 		}
 	}
 	return max

--- a/internal/game/game_test.go
+++ b/internal/game/game_test.go
@@ -153,7 +153,7 @@ func TestShowShopWithItems(t *testing.T) {
 // TestHandSizeWithJoker verifies that a joker can increase the hand size.
 func TestHandSizeWithJoker(t *testing.T) {
 	g := &Game{
-		jokers: []Joker{{Effect: AddHandSize, EffectMagnitude: 2}},
+		jokers: []Joker{{Effects: []JokerEffectConfig{{Effect: AddHandSize, EffectMagnitude: 2}}}},
 	}
 	if got := g.handSize(); got != InitialCards+2 {
 		t.Fatalf("expected hand size %d, got %d", InitialCards+2, got)
@@ -168,7 +168,7 @@ func TestDiscardLimitWithJoker(t *testing.T) {
 		deck:         deck,
 		deckIndex:    InitialCards,
 		playerCards:  deck[:InitialCards],
-		jokers:       []Joker{{Effect: AddDiscards, EffectMagnitude: 2}},
+		jokers:       []Joker{{Effects: []JokerEffectConfig{{Effect: AddDiscards, EffectMagnitude: 2}}}},
 		eventEmitter: NewEventEmitter(),
 	}
 	g.eventEmitter.SetEventHandler(handler)

--- a/internal/game/jokers.go
+++ b/internal/game/jokers.go
@@ -47,16 +47,27 @@ const (
 	CardIsFace  CardMatchingRule = "IsFace"
 )
 
-// JokerConfig represents a joker configuration from YAML
-type JokerConfig struct {
-	Name             string           `yaml:"name"`
-	Value            int              `yaml:"value"`
-	Rarity           string           `yaml:"rarity"`
+// JokerEffectConfig represents a single effect component of a joker
+type JokerEffectConfig struct {
 	Effect           JokerEffect      `yaml:"effect"`
 	EffectMagnitude  int              `yaml:"effect_magnitude"`
 	HandMatchingRule HandMatchingRule `yaml:"hand_matching_rule"`
 	CardMatchingRule CardMatchingRule `yaml:"card_matching_rule"`
-	Description      string           `yaml:"description"`
+}
+
+// JokerConfig represents a joker configuration from YAML
+type JokerConfig struct {
+	Name        string `yaml:"name"`
+	Value       int    `yaml:"value"`
+	Rarity      string `yaml:"rarity"`
+	Description string `yaml:"description"`
+	// Legacy single-effect fields for backward compatibility
+	Effect           JokerEffect      `yaml:"effect"`
+	EffectMagnitude  int              `yaml:"effect_magnitude"`
+	HandMatchingRule HandMatchingRule `yaml:"hand_matching_rule"`
+	CardMatchingRule CardMatchingRule `yaml:"card_matching_rule"`
+	// Composite effects
+	Effects []JokerEffectConfig `yaml:"effects"`
 }
 
 // JokersYAML represents the root YAML structure
@@ -66,15 +77,10 @@ type JokersYAML struct {
 
 // Joker represents a joker card that modifies gameplay
 type Joker struct {
-	Name             string
-	Description      string
-	Price            int
-	Effect           JokerEffect
-	EffectMagnitude  int
-	HandMatchingRule HandMatchingRule
-	CardMatchingRule CardMatchingRule
-	OnBlindEnd       func() int                      // Returns money earned at end of blind
-	OnHandScoring    func(string, []Card) (int, int) // Returns (chips, mult) bonus for hand
+	Name        string
+	Description string
+	Price       int
+	Effects     []JokerEffectConfig
 }
 
 var jokerConfigs []JokerConfig
@@ -121,97 +127,100 @@ func loadJokersFromYAML() error {
 func setDefaultJokerConfigs() {
 	jokerConfigs = []JokerConfig{
 		{
-			Name:             "The Golden Joker",
-			Value:            6,
-			Rarity:           "Common",
-			Effect:           AddMoney,
-			EffectMagnitude:  4,
-			HandMatchingRule: None,
-			CardMatchingRule: CardNone,
-			Description:      "Earn $4 at the end of each Blind",
+			Name:   "The Golden Joker",
+			Value:  6,
+			Rarity: "Common",
+			Effects: []JokerEffectConfig{
+				{
+					Effect:           AddMoney,
+					EffectMagnitude:  4,
+					HandMatchingRule: None,
+					CardMatchingRule: CardNone,
+				},
+			},
+			Description: "Earn $4 at the end of each Blind",
 		},
 		{
-			Name:             "Chip Collector",
-			Value:            5,
-			Rarity:           "Common",
-			Effect:           AddChips,
-			EffectMagnitude:  30,
-			HandMatchingRule: ContainsPair,
-			CardMatchingRule: CardNone,
-			Description:      "+30 Chips if played hand contains a Pair",
+			Name:   "Chip Collector",
+			Value:  5,
+			Rarity: "Common",
+			Effects: []JokerEffectConfig{
+				{
+					Effect:           AddChips,
+					EffectMagnitude:  30,
+					HandMatchingRule: ContainsPair,
+					CardMatchingRule: CardNone,
+				},
+			},
+			Description: "+30 Chips if played hand contains a Pair",
 		},
 		{
-			Name:             "Double Down",
-			Value:            4,
-			Rarity:           "Common",
-			Effect:           AddMult,
-			EffectMagnitude:  8,
-			HandMatchingRule: ContainsPair,
-			CardMatchingRule: CardNone,
-			Description:      "+8 Mult if played hand contains a Pair",
+			Name:   "Double Down",
+			Value:  4,
+			Rarity: "Common",
+			Effects: []JokerEffectConfig{
+				{
+					Effect:           AddMult,
+					EffectMagnitude:  8,
+					HandMatchingRule: ContainsPair,
+					CardMatchingRule: CardNone,
+				},
+			},
+			Description: "+8 Mult if played hand contains a Pair",
 		},
 		{
-			Name:             "Face Dancer",
-			Value:            7,
-			Rarity:           "Common",
-			Effect:           ReplayCard,
-			EffectMagnitude:  0,
-			HandMatchingRule: None,
-			CardMatchingRule: CardIsFace,
-			Description:      "Face cards are scored twice",
+			Name:   "Face Dancer",
+			Value:  7,
+			Rarity: "Common",
+			Effects: []JokerEffectConfig{
+				{
+					Effect:           ReplayCard,
+					EffectMagnitude:  0,
+					HandMatchingRule: None,
+					CardMatchingRule: CardIsFace,
+				},
+			},
+			Description: "Face cards are scored twice",
 		},
 	}
 }
 
 // createJokerFromConfig creates a Joker instance from a JokerConfig
 func createJokerFromConfig(config JokerConfig) Joker {
-	cardRule := config.CardMatchingRule
-	if cardRule == "" {
-		cardRule = CardNone
-	}
+	var effects []JokerEffectConfig
 
-	joker := Joker{
-		Name:             config.Name,
-		Description:      config.Description,
-		Price:            config.Value,
-		Effect:           config.Effect,
-		EffectMagnitude:  config.EffectMagnitude,
-		HandMatchingRule: config.HandMatchingRule,
-		CardMatchingRule: cardRule,
-	}
-
-	// Set up effect functions based on effect type
-	switch config.Effect {
-	case AddMoney:
-		joker.OnBlindEnd = func() int {
-			return config.EffectMagnitude
+	if len(config.Effects) > 0 {
+		for _, e := range config.Effects {
+			cardRule := e.CardMatchingRule
+			if cardRule == "" {
+				cardRule = CardNone
+			}
+			effects = append(effects, JokerEffectConfig{
+				Effect:           e.Effect,
+				EffectMagnitude:  e.EffectMagnitude,
+				HandMatchingRule: e.HandMatchingRule,
+				CardMatchingRule: cardRule,
+			})
 		}
-	case AddChips, AddMult:
-		joker.OnHandScoring = func(handType string, cards []Card) (int, int) {
-			matches := 0
-			if cardRule != CardNone {
-				for _, c := range cards {
-					if cardMatchesRule(c, cardRule) {
-						matches++
-					}
-				}
-			} else if handMatchesRule(handType, config.HandMatchingRule) {
-				matches = 1
-			}
-			if matches == 0 {
-				return 0, 0
-			}
-			bonus := config.EffectMagnitude * matches
-			if config.Effect == AddChips {
-				return bonus, 0
-			}
-			return 0, bonus
+	} else if config.Effect != "" {
+		cardRule := config.CardMatchingRule
+		if cardRule == "" {
+			cardRule = CardNone
 		}
-	case AddHandSize, AddDiscards:
-		// Passive effects handled directly in game logic
+		effects = append(effects, JokerEffectConfig{
+			Effect:           config.Effect,
+			EffectMagnitude:  config.EffectMagnitude,
+			HandMatchingRule: config.HandMatchingRule,
+			CardMatchingRule: cardRule,
+		})
 	}
 
-	return joker
+	return Joker{
+		Name:        config.Name,
+		Description: config.Description,
+		Price:       config.Value,
+		Effects:     effects,
+	}
 }
 
 // handMatchesRule checks if a hand type matches a given rule
@@ -325,9 +334,13 @@ func GetGoldenJoker() Joker {
 		Name:        "The Golden Joker",
 		Description: "Earn $4 at the end of each Blind",
 		Price:       6,
-		Effect:      AddMoney,
-		OnBlindEnd: func() int {
-			return 4
+		Effects: []JokerEffectConfig{
+			{
+				Effect:           AddMoney,
+				EffectMagnitude:  4,
+				HandMatchingRule: None,
+				CardMatchingRule: CardNone,
+			},
 		},
 	}
 }
@@ -346,8 +359,10 @@ func PlayerHasJoker(playerJokers []Joker, jokerName string) bool {
 func CalculateJokerRewards(jokers []Joker) int {
 	total := 0
 	for _, joker := range jokers {
-		if joker.OnBlindEnd != nil {
-			total += joker.OnBlindEnd()
+		for _, eff := range joker.Effects {
+			if eff.Effect == AddMoney {
+				total += eff.EffectMagnitude
+			}
 		}
 	}
 	return total
@@ -359,10 +374,29 @@ func CalculateJokerHandBonus(jokers []Joker, handType string, cards []Card) (int
 	totalMult := 0
 
 	for _, joker := range jokers {
-		if joker.OnHandScoring != nil {
-			chips, mult := joker.OnHandScoring(handType, cards)
-			totalChips += chips
-			totalMult += mult
+		for _, eff := range joker.Effects {
+			switch eff.Effect {
+			case AddChips, AddMult:
+				matches := 0
+				if eff.CardMatchingRule != CardNone {
+					for _, c := range cards {
+						if cardMatchesRule(c, eff.CardMatchingRule) {
+							matches++
+						}
+					}
+				} else if handMatchesRule(handType, eff.HandMatchingRule) {
+					matches = 1
+				}
+				if matches == 0 {
+					continue
+				}
+				bonus := eff.EffectMagnitude * matches
+				if eff.Effect == AddChips {
+					totalChips += bonus
+				} else {
+					totalMult += bonus
+				}
+			}
 		}
 	}
 
@@ -376,11 +410,13 @@ func ApplyReplayCardEffects(jokers []Joker, cards []Card) ([]Card, int) {
 	var replayed []Card
 	extraValue := 0
 	for _, joker := range jokers {
-		if joker.Effect == ReplayCard && joker.CardMatchingRule != CardNone {
-			for _, c := range cards {
-				if cardMatchesRule(c, joker.CardMatchingRule) {
-					replayed = append(replayed, c)
-					extraValue += c.Rank.Value()
+		for _, eff := range joker.Effects {
+			if eff.Effect == ReplayCard && eff.CardMatchingRule != CardNone {
+				for _, c := range cards {
+					if cardMatchesRule(c, eff.CardMatchingRule) {
+						replayed = append(replayed, c)
+						extraValue += c.Rank.Value()
+					}
 				}
 			}
 		}
@@ -410,8 +446,11 @@ func FormatJokersList(jokers []Joker) string {
 func GetJokersByEffect(jokers []Joker, effect JokerEffect) []Joker {
 	var filtered []Joker
 	for _, joker := range jokers {
-		if joker.Effect == effect {
-			filtered = append(filtered, joker)
+		for _, eff := range joker.Effects {
+			if eff.Effect == effect {
+				filtered = append(filtered, joker)
+				break
+			}
 		}
 	}
 	return filtered

--- a/internal/game/jokers_test.go
+++ b/internal/game/jokers_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 // TestCalculateJokerRewards verifies AddMoney joker rewards at blind end.
 func TestCalculateJokerRewards(t *testing.T) {
-	j := Joker{OnBlindEnd: func() int { return 4 }}
+	j := Joker{Effects: []JokerEffectConfig{{Effect: AddMoney, EffectMagnitude: 4}}}
 	if got := CalculateJokerRewards([]Joker{j}); got != 4 {
 		t.Fatalf("expected 4, got %d", got)
 	}
@@ -12,10 +12,10 @@ func TestCalculateJokerRewards(t *testing.T) {
 
 // TestCalculateJokerHandBonus verifies chip and multiplier bonuses from jokers.
 func TestCalculateJokerHandBonus(t *testing.T) {
-	chipCfg := JokerConfig{Name: "Chip", Effect: AddChips, EffectMagnitude: 30, HandMatchingRule: ContainsPair}
+	chipCfg := JokerConfig{Name: "Chip", Effects: []JokerEffectConfig{{Effect: AddChips, EffectMagnitude: 30, HandMatchingRule: ContainsPair}}}
 	chipJoker := createJokerFromConfig(chipCfg)
 
-	multCfg := JokerConfig{Name: "Mult", Effect: AddMult, EffectMagnitude: 5, HandMatchingRule: ContainsPair}
+	multCfg := JokerConfig{Name: "Mult", Effects: []JokerEffectConfig{{Effect: AddMult, EffectMagnitude: 5, HandMatchingRule: ContainsPair}}}
 	multJoker := createJokerFromConfig(multCfg)
 
 	chips, mult := CalculateJokerHandBonus([]Joker{chipJoker}, "Pair", []Card{})
@@ -37,7 +37,7 @@ func TestCalculateJokerHandBonus(t *testing.T) {
 
 // TestCardMatchingRule verifies bonuses based on individual card matches.
 func TestCardMatchingRule(t *testing.T) {
-	cfg := JokerConfig{Name: "Ace Bonus", Effect: AddChips, EffectMagnitude: 10, CardMatchingRule: CardIsAce}
+	cfg := JokerConfig{Name: "Ace Bonus", Effects: []JokerEffectConfig{{Effect: AddChips, EffectMagnitude: 10, CardMatchingRule: CardIsAce}}}
 	joker := createJokerFromConfig(cfg)
 
 	hand := []Card{{Rank: Ace, Suit: Hearts}, {Rank: Ace, Suit: Spades}, {Rank: Two, Suit: Clubs}}
@@ -55,9 +55,9 @@ func TestCardMatchingRule(t *testing.T) {
 
 // TestReplayFaceCards verifies that ReplayCard jokers process matching cards twice.
 func TestReplayFaceCards(t *testing.T) {
-	replayCfg := JokerConfig{Name: "Face Dancer", Effect: ReplayCard, CardMatchingRule: CardIsFace}
+	replayCfg := JokerConfig{Name: "Face Dancer", Effects: []JokerEffectConfig{{Effect: ReplayCard, CardMatchingRule: CardIsFace}}}
 	replayJoker := createJokerFromConfig(replayCfg)
-	bonusCfg := JokerConfig{Name: "Face Bonus", Effect: AddChips, EffectMagnitude: 10, CardMatchingRule: CardIsFace}
+	bonusCfg := JokerConfig{Name: "Face Bonus", Effects: []JokerEffectConfig{{Effect: AddChips, EffectMagnitude: 10, CardMatchingRule: CardIsFace}}}
 	bonusJoker := createJokerFromConfig(bonusCfg)
 
 	cards := []Card{{Rank: Jack, Suit: Hearts}, {Rank: Five, Suit: Clubs}}
@@ -73,5 +73,21 @@ func TestReplayFaceCards(t *testing.T) {
 
 	if finalScore != 50 {
 		t.Fatalf("expected final score 50, got %d", finalScore)
+	}
+}
+
+// TestCompositeJoker verifies that multiple effects on a single joker stack.
+func TestCompositeJoker(t *testing.T) {
+	cfg := JokerConfig{
+		Name: "Combo",
+		Effects: []JokerEffectConfig{
+			{Effect: AddChips, EffectMagnitude: 10, HandMatchingRule: ContainsPair},
+			{Effect: AddMult, EffectMagnitude: 2, HandMatchingRule: ContainsPair},
+		},
+	}
+	joker := createJokerFromConfig(cfg)
+	chips, mult := CalculateJokerHandBonus([]Joker{joker}, "Pair", []Card{})
+	if chips != 10 || mult != 2 {
+		t.Fatalf("expected chips=10 mult=2, got chips=%d mult=%d", chips, mult)
 	}
 }


### PR DESCRIPTION
## Summary
- support multiple effects per joker via new `effects` array
- handle composite effects during scoring and card replays
- document composite joker configuration and update examples

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b52f9eadc832ca9508374943b238c