### PR TITLE
Organize save files into dedicated folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 balatno
 balatno-tui
+saves/

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ go run . -seed 42
 go run . -tui -seed 42
 
 # Load a saved game
-go run . -load save.json
+go run . -load saves/save.json
 ```
 
 # Automatic saving
-When you quit the game or it times out, the current state is saved to a timestamped JSON file like `2025-08-11T16:38:12Z.json`. The file will not be written if the process is interrupted with `Ctrl+C`.
+When you quit the game or it times out, the current state is saved to the `saves/` directory as a timestamped JSON file like `saves/2025-08-11T16:38:12Z.json`. The file will not be written if the process is interrupted with `Ctrl+C`.
 
 The JSON file should contain:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -321,5 +321,5 @@ This implementation brings Balatro CLI significantly closer to the authentic Bal
 ## 💾 Save & Load
 
 - **Load from JSON**: Resume a run using `-load <file>`
-- **Auto-save**: Game state written to timestamped JSON when quitting or timing out
+- **Auto-save**: Game state written to `saves/` as timestamped JSON when quitting or timing out
 - **Save format**: JSON with `save_version`, `seed`, `current_ante`, `current_blind`, `current_money`, and `current_jokers`

--- a/internal/game/save.go
+++ b/internal/game/save.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -92,7 +93,11 @@ func (g *Game) Save() (string, error) {
 		return "", err
 	}
 
-	filename := time.Now().UTC().Format(time.RFC3339) + ".json"
+	if err := os.MkdirAll("saves", 0755); err != nil {
+		return "", err
+	}
+
+	filename := filepath.Join("saves", time.Now().UTC().Format(time.RFC3339)+".json")
 	if err := os.WriteFile(filename, data, 0644); err != nil {
 		return "", err
 	}

--- a/internal/game/save_load_test.go
+++ b/internal/game/save_load_test.go
@@ -3,6 +3,7 @@ package game
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -62,7 +63,7 @@ func TestSaveGameToFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Save returned error: %v", err)
 	}
-	defer os.Remove(filename)
+	defer os.RemoveAll(filepath.Dir(filename))
 
 	data, err := os.ReadFile(filename)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Redirect save files into a `saves/` directory and ignore it in git
- Update tests and documentation for the new save location

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b52f64608832cb60ad230f66b74b1