### PR TITLE
Display boss blind name in game info

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -204,8 +204,12 @@ func (g *Game) Run() {
 		for g.handsPlayed < MaxHands && g.totalScore < g.currentTarget {
 			// Update display mapping and emit current state
 			g.updateDisplayToOriginalMapping()
+			bossName := ""
+			if g.currentBlind == BossBlind {
+				bossName = g.currentBoss.Description()
+			}
 			g.eventEmitter.EmitGameState(g.currentAnte, g.currentBlind, g.currentTarget, g.totalScore,
-				MaxHands-g.handsPlayed, g.maxDiscards()-g.discardsUsed, g.money, g.jokers)
+				MaxHands-g.handsPlayed, g.maxDiscards()-g.discardsUsed, g.money, g.jokers, bossName)
 			g.eventEmitter.EmitCardsDealt(g.playerCards, g.displayToOriginal, g.sortMode)
 
 			action, params, quit := g.eventEmitter.handler.GetPlayerAction(g.discardsUsed < g.maxDiscards())
@@ -936,6 +940,10 @@ func (g *Game) handleMoveJokerAction(params []string) {
 		return
 	}
 
+	bossName := ""
+	if g.currentBlind == BossBlind {
+		bossName = g.currentBoss.Description()
+	}
 	g.eventEmitter.EmitGameState(g.currentAnte, g.currentBlind, g.currentTarget, g.totalScore,
-		MaxHands-g.handsPlayed, g.maxDiscards()-g.discardsUsed, g.money, g.jokers)
+		MaxHands-g.handsPlayed, g.maxDiscards()-g.discardsUsed, g.money, g.jokers, bossName)
 }

--- a/internal/game/game_events.go
+++ b/internal/game/game_events.go
@@ -57,6 +57,7 @@ type GameStateChangedEvent struct {
 	Discards int
 	Money    int
 	Jokers   []Joker
+	Boss     string
 }
 
 func (e GameStateChangedEvent) EventType() string { return "game_state_changed" }
@@ -224,7 +225,7 @@ func (e *SimpleEventEmitter) EmitGameStarted() {
 	e.EmitEvent(GameStartedEvent{})
 }
 
-func (e *SimpleEventEmitter) EmitGameState(ante int, blind BlindType, target, score, hands, discards, money int, jokers []Joker) {
+func (e *SimpleEventEmitter) EmitGameState(ante int, blind BlindType, target, score, hands, discards, money int, jokers []Joker, boss string) {
 	e.EmitEvent(GameStateChangedEvent{
 		Ante:     ante,
 		Blind:    blind,
@@ -234,6 +235,7 @@ func (e *SimpleEventEmitter) EmitGameState(ante int, blind BlindType, target, sc
 		Discards: discards,
 		Money:    money,
 		Jokers:   jokers,
+		Boss:     boss,
 	})
 }
 

--- a/internal/game/logger_event_handler.go
+++ b/internal/game/logger_event_handler.go
@@ -74,7 +74,11 @@ func (h *LoggerEventHandler) handleGameStarted() {
 }
 
 func (h *LoggerEventHandler) handleGameStateChanged(e GameStateChangedEvent) {
-	fmt.Printf("🎯 Ante %d - %s | Target: %d | Current Score: %d\n", e.Ante, e.Blind, e.Target, e.Score)
+	blindName := e.Blind.String()
+	if e.Blind == BossBlind && e.Boss != "" {
+		blindName = fmt.Sprintf("%s: %s", blindName, e.Boss)
+	}
+	fmt.Printf("🎯 Ante %d - %s | Target: %d | Current Score: %d\n", e.Ante, blindName, e.Target, e.Score)
 	fmt.Printf("🎴 Hands Left: %d | 🗑️ Discards Left: %d | 💰 Money: $%d\n", e.Hands, e.Discards, e.Money)
 
 	if len(e.Jokers) > 0 {

--- a/internal/ui/tui_game.go
+++ b/internal/ui/tui_game.go
@@ -45,7 +45,11 @@ func (gm GameMode) renderContent(m TUIModel) string {
 		blindEmoji = "💀"
 	}
 
-	gameInfo := fmt.Sprintf("%s Ante %d - %s\n", blindEmoji, m.gameState.Ante, m.gameState.Blind) +
+	blindText := m.gameState.Blind.String()
+	if m.gameState.Blind == game.BossBlind && m.gameState.Boss != "" {
+		blindText = fmt.Sprintf("%s: %s", blindText, m.gameState.Boss)
+	}
+	gameInfo := fmt.Sprintf("%s Ante %d - %s\n", blindEmoji, m.gameState.Ante, blindText) +
 		fmt.Sprintf("🎯 Target: %d | Current Score: %d [%s] (%.1f%%)\n",
 			m.gameState.Target, m.gameState.Score, progressBar, progress*100) +
 		fmt.Sprintf("🎴 Hands Left: %d | 🗑️ Discards Left: %d | 💰 Money: $%d",

--- a/internal/ui/tui_shop.go
+++ b/internal/ui/tui_shop.go
@@ -17,7 +17,11 @@ type ShoppingMode struct {
 }
 
 func (ms ShoppingMode) renderContent(m TUIModel) string {
-	gameInfo := fmt.Sprintf("%s Ante %d - %s✅\n", "🏪", m.gameState.Ante, m.gameState.Blind) +
+	blindText := m.gameState.Blind.String()
+	if m.gameState.Blind == game.BossBlind && m.gameState.Boss != "" {
+		blindText = fmt.Sprintf("%s: %s", blindText, m.gameState.Boss)
+	}
+	gameInfo := fmt.Sprintf("%s Ante %d - %s✅\n", "🏪", m.gameState.Ante, blindText) +
 		fmt.Sprintf("🎴 Hands: %d | 🗑️ Discards: %d | 💰 Money: $%d | 🎲 Reroll: $%d",
 			m.gameState.Hands, m.gameState.Discards, m.gameState.Money, m.shopInfo.RerollCost)
 	gameInfoBox := gameInfoStyle.

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -204,5 +205,27 @@ func TestJokerReorder(t *testing.T) {
 
 	if m.gameState.Jokers[0].Name != "J2" {
 		t.Fatalf("expected J2 to move up, got %v", m.gameState.Jokers)
+	}
+}
+
+// TestBossBlindNameInGameInfo ensures boss blind name appears in the game info box.
+func TestBossBlindNameInGameInfo(t *testing.T) {
+	m := TUIModel{
+		gameState: game.GameStateChangedEvent{
+			Ante:     1,
+			Blind:    game.BossBlind,
+			Target:   100,
+			Score:    0,
+			Hands:    4,
+			Discards: 3,
+			Money:    0,
+			Boss:     "Hearts score zero",
+		},
+		mode:  GameMode{},
+		cards: []game.Card{},
+	}
+	content := GameMode{}.renderContent(m)
+	if !strings.Contains(content, "Boss Blind: Hearts score zero") {
+		t.Fatalf("boss blind name not found in game info: %s", content)
 	}
 }


### PR DESCRIPTION
## Summary
- show boss blind name when playing or shopping
- include boss effect in game state events
- test boss blind name rendering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b576e3ca4832c8008d8df2757cee0