### PR TITLE
Fix joker reorder dialog to reorder selected cards

### DIFF
--- a/internal/ui/tui_jokers.go
+++ b/internal/ui/tui_jokers.go
@@ -13,12 +13,12 @@ import (
 // JokerOrderMode allows players to reorder owned jokers.
 type JokerOrderMode struct {
 	prevMode Mode
-	selected *int
+	selected int // -1 indicates no selection
 }
 
 // NewJokerOrderMode returns a JokerOrderMode wrapping the previous mode.
 func NewJokerOrderMode(prev Mode) *JokerOrderMode {
-	return &JokerOrderMode{prevMode: prev}
+	return &JokerOrderMode{prevMode: prev, selected: -1}
 }
 
 func (jm JokerOrderMode) renderContent(m TUIModel) string {
@@ -29,7 +29,7 @@ func (jm JokerOrderMode) renderContent(m TUIModel) string {
 	for i, j := range m.gameState.Jokers {
 		line := fmt.Sprintf("%d. %s: %s", i+1, j.Name, j.Description)
 		style := lipgloss.NewStyle()
-		if jm.selected != nil && *jm.selected == i {
+		if jm.selected == i {
 			style = style.Foreground(lipgloss.Color("226")).Bold(true)
 		}
 		lines = append(lines, style.Render(line))
@@ -47,34 +47,33 @@ func (jm *JokerOrderMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, te
 	case "1", "2", "3", "4", "5", "6", "7", "8", "9":
 		idx, _ := strconv.Atoi(msg)
 		if idx <= len(m.gameState.Jokers) {
-			idx--
-			jm.selected = &idx
+			jm.selected = idx - 1
 		} else {
 			m.setStatusMessage(fmt.Sprintf("Invalid joker number: %s", msg))
 		}
 		return m, nil
 	case "up", "k":
-		if jm.selected == nil {
+		if jm.selected == -1 {
 			m.setStatusMessage("Select a joker first")
 			return m, nil
 		}
-		if *jm.selected > 0 {
-			m.sendAction(game.PlayerActionMoveJoker, []string{strconv.Itoa(*jm.selected + 1), "up"})
-			m.gameState.Jokers[*jm.selected-1], m.gameState.Jokers[*jm.selected] = m.gameState.Jokers[*jm.selected], m.gameState.Jokers[*jm.selected-1]
-			*jm.selected--
+		if jm.selected > 0 {
+			m.sendAction(game.PlayerActionMoveJoker, []string{strconv.Itoa(jm.selected + 1), "up"})
+			m.gameState.Jokers[jm.selected-1], m.gameState.Jokers[jm.selected] = m.gameState.Jokers[jm.selected], m.gameState.Jokers[jm.selected-1]
+			jm.selected--
 		} else {
 			m.setStatusMessage("Joker already at top")
 		}
 		return m, nil
 	case "down", "j":
-		if jm.selected == nil {
+		if jm.selected == -1 {
 			m.setStatusMessage("Select a joker first")
 			return m, nil
 		}
-		if *jm.selected < len(m.gameState.Jokers)-1 {
-			m.sendAction(game.PlayerActionMoveJoker, []string{strconv.Itoa(*jm.selected + 1), "down"})
-			m.gameState.Jokers[*jm.selected], m.gameState.Jokers[*jm.selected+1] = m.gameState.Jokers[*jm.selected+1], m.gameState.Jokers[*jm.selected]
-			*jm.selected++
+		if jm.selected < len(m.gameState.Jokers)-1 {
+			m.sendAction(game.PlayerActionMoveJoker, []string{strconv.Itoa(jm.selected + 1), "down"})
+			m.gameState.Jokers[jm.selected], m.gameState.Jokers[jm.selected+1] = m.gameState.Jokers[jm.selected+1], m.gameState.Jokers[jm.selected]
+			jm.selected++
 		} else {
 			m.setStatusMessage("Joker already at bottom")
 		}


### PR DESCRIPTION
## Summary
- allow joker reorder dialog to track selection with index instead of pointer
- move jokers when pressing up/down arrows

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b54046f08832c8f37e0ba30f30e00