### PR TITLE
Render jokers in game info box upon purchase

### DIFF
--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -680,6 +680,8 @@ func (g *Game) showShop() {
 						Item:           NewShopItemData(selectedJoker, g.money+selectedJoker.Price),
 						RemainingMoney: g.money,
 					})
+					g.eventEmitter.EmitGameState(g.currentAnte, g.currentBlind, g.currentTarget, g.totalScore,
+						MaxHands-g.handsPlayed, g.maxDiscards()-g.discardsUsed, g.money, g.jokers)
 
 					// Remove purchased item and update available jokers
 					shopItems[choice-1] = Joker{}
@@ -815,6 +817,8 @@ func (g *Game) showShopWithItems(availableJokers []Joker, shopItems []Joker) {
 						Item:           NewShopItemData(selectedJoker, g.money+selectedJoker.Price),
 						RemainingMoney: g.money,
 					})
+					g.eventEmitter.EmitGameState(g.currentAnte, g.currentBlind, g.currentTarget, g.totalScore,
+						MaxHands-g.handsPlayed, g.maxDiscards()-g.discardsUsed, g.money, g.jokers)
 
 					// Remove purchased item
 					shopItems[choice-1] = Joker{}


### PR DESCRIPTION
## Summary
- Emit game state updates after buying shop items so newly owned jokers appear in the game info box immediately.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b5f88eca0832cbe8ac9d539a0e2a1