### PR TITLE
Add YAML-configurable boss system with final boss gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ BALATRO_TIMEOUT=300 ./balatro -tui
 - **8 Antes** total to complete the game
 - Each Ante contains **3 Blinds** in sequence:
   - 🔸 **Small Blind** - Base difficulty
-  - 🔶 **Big Blind** - 1.5x harder than Small Blind  
-  - 💀 **Boss Blind** - 2x harder than Small Blind (special rules coming soon!)
+  - 🔶 **Big Blind** - 1.5x harder than Small Blind
+  - 💀 **Boss Blind** - 2x harder than Small Blind and features a boss with special effects
 - **🏪 Shop** appears between each blind where you can spend money on Jokers
 
 ### Each Blind Challenge
@@ -277,6 +277,9 @@ Between each blind, you visit the **🏪 Shop** where you can:
 - **Double Down** ($4): +8 mult for hands containing pairs
 - **Straight Shooter** ($8): +100 chips for hands containing straights
 
+### YAML Boss System
+**💀 Configurable via `bosses.yaml`** - Define boss names and effects. Bosses marked with `final: true` only appear on antes divisible by 8.
+
 ### Money Management Tips
 - **Efficiency Rewards**: Unused hands/discards = more money
 - **Early Investment**: The Golden Joker quickly pays for itself
@@ -390,6 +393,8 @@ The codebase is organized into focused, modular files:
 - **`game.go`** - Ante/Blind progression, game loop, and player interaction
 - **`jokers.go`** - YAML joker system, shop mechanics, and effect processing
 - **`jokers.yaml`** - Joker definitions and balance configuration
+- **`bosses.go`** - YAML boss system and selection logic
+- **`bosses.yaml`** - Boss definitions
 
 ### Ante/Blind System
 
@@ -469,7 +474,7 @@ type HandEvaluator interface {
 
 This implementation includes core progression with **YAML-configurable joker systems**. The full Balatro experience also includes:
 
-- **Boss Blind Effects**: Special rules and constraints for Boss Blinds *(coming soon!)*
+- **More Boss Blind Effects**: Additional special rules for Boss Blinds
 - **Extended Joker Effects**: Conditional triggers, card-specific bonuses, deck modifications
 - **Advanced Shop Items**: Tarot cards, Planet cards, and card packs
 - **Card Enhancements**: Foil, holographic, and other card modifications
@@ -477,7 +482,7 @@ This implementation includes core progression with **YAML-configurable joker sys
 - **Stakes**: Higher difficulty modes with additional constraints
 - **Endless Mode**: Continue beyond Ante 8 for ultimate challenges
 
-**✅ Currently Implemented**: Ante progression, money system, shop, **YAML joker system with 15+ configurable jokers**
+**✅ Currently Implemented**: Ante progression, money system, shop, **YAML joker system with 15+ configurable jokers**, **YAML-configured bosses with in-game effects**
 
 ---
 

--- a/docs/BOSS_CONFIG.md
+++ b/docs/BOSS_CONFIG.md
@@ -1,0 +1,23 @@
+# YAML Boss Configuration
+
+Bosses are defined in `bosses.yaml` and loaded at runtime.
+
+## `bosses.yaml` Structure
+
+```yaml
+bosses:
+  - name: "Skull King"
+    effect: "DoubleChips"
+  - name: "The Void"
+    effect: "HalveMoney"
+    final: true
+```
+
+- `name`: Display name of the boss.
+- `effect`: Identifier for the boss effect.
+- `final`: Optional flag. Final bosses only appear on antes divisible by 8.
+
+## Available Effects
+
+- `DoubleChips` – Doubles the chip target needed to defeat the blind.
+- `HalveMoney` – Halves the player's money when the blind starts.

--- a/internal/game/boss_effects_test.go
+++ b/internal/game/boss_effects_test.go
@@ -1,0 +1,19 @@
+package game
+
+import "testing"
+
+func TestApplyBossEffect(t *testing.T) {
+	g := &Game{currentTarget: 100, money: 200}
+
+	g.currentBoss = Boss{Effect: DoubleChips}
+	g.applyBossEffect()
+	if g.currentTarget != 200 {
+		t.Errorf("expected target 200, got %d", g.currentTarget)
+	}
+
+	g.currentBoss = Boss{Effect: HalveMoney}
+	g.applyBossEffect()
+	if g.money != 100 {
+		t.Errorf("expected money 100, got %d", g.money)
+	}
+}

--- a/internal/game/bosses.go
+++ b/internal/game/bosses.go
@@ -1,0 +1,104 @@
+package game
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+// BossEffect represents the type of effect a boss applies
+type BossEffect string
+
+const (
+	// DoubleChips doubles the chip target needed to defeat the blind
+	DoubleChips BossEffect = "DoubleChips"
+	// HalveMoney halves the player's money when the blind starts
+	HalveMoney BossEffect = "HalveMoney"
+)
+
+type Boss struct {
+	Name   string     `yaml:"name"`
+	Effect BossEffect `yaml:"effect"`
+	Final  bool       `yaml:"final"`
+}
+
+type BossesYAML struct {
+	Bosses []Boss `yaml:"bosses"`
+}
+
+var regularBosses []Boss
+var finalBosses []Boss
+
+func LoadBossConfigs() error {
+	if err := loadBossesFromYAML(); err != nil {
+		fmt.Printf("Warning: Could not load bosses.yaml, using defaults: %v\n", err)
+		setDefaultBosses()
+	}
+	return nil
+}
+
+func loadBossesFromYAML() error {
+	regularBosses = nil
+	finalBosses = nil
+
+	file, err := os.Open(filepath.Join("internal", "game", "bosses.yaml"))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
+	var bossesYAML BossesYAML
+	if err := yaml.Unmarshal(data, &bossesYAML); err != nil {
+		return err
+	}
+	if len(bossesYAML.Bosses) == 0 {
+		return fmt.Errorf("bosses.yaml contains no bosses")
+	}
+
+	for _, b := range bossesYAML.Bosses {
+		if b.Final {
+			finalBosses = append(finalBosses, b)
+		} else {
+			regularBosses = append(regularBosses, b)
+		}
+	}
+
+	return nil
+}
+
+func setDefaultBosses() {
+	regularBosses = []Boss{
+		{Name: "Skull King", Effect: DoubleChips},
+	}
+	finalBosses = []Boss{
+		{Name: "The Void", Effect: HalveMoney, Final: true},
+	}
+}
+
+func GetBossForAnte(ante int) Boss {
+	if ante%8 == 0 {
+		if len(finalBosses) > 0 {
+			return finalBosses[(ante/8-1)%len(finalBosses)]
+		}
+	} else {
+		if len(regularBosses) > 0 {
+			return regularBosses[(ante-1)%len(regularBosses)]
+		}
+	}
+
+	if len(finalBosses) > 0 {
+		return finalBosses[0]
+	}
+	if len(regularBosses) > 0 {
+		return regularBosses[0]
+	}
+	return Boss{}
+}

--- a/internal/game/bosses.yaml
+++ b/internal/game/bosses.yaml
@@ -1,0 +1,6 @@
+bosses:
+  - name: "Skull King"
+    effect: "DoubleChips"
+  - name: "The Void"
+    effect: "HalveMoney"
+    final: true

--- a/internal/game/game_events.go
+++ b/internal/game/game_events.go
@@ -126,6 +126,7 @@ type NewBlindStartedEvent struct {
 	Blind    BlindType
 	Target   int
 	NewCards []Card
+	Boss     *Boss
 }
 
 func (e NewBlindStartedEvent) EventType() string { return "new_blind_started" }

--- a/internal/game/logger_event_handler.go
+++ b/internal/game/logger_event_handler.go
@@ -214,6 +214,9 @@ func (h *LoggerEventHandler) handleNewBlindStarted(e NewBlindStartedEvent) {
 
 	fmt.Printf("%s NOW ENTERING: %s (Ante %d) %s\n", blindEmoji, e.Blind, e.Ante, blindEmoji)
 	fmt.Printf("🎯 NEW TARGET: %d points\n", e.Target)
+	if e.Blind == BossBlind && e.Boss != nil {
+		fmt.Printf("👑 Boss: %s - %s\n", e.Boss.Name, e.Boss.Effect)
+	}
 	fmt.Println("🃏 Fresh hand dealt!")
 	fmt.Println(strings.Repeat("-", 40))
 	fmt.Println()

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -271,6 +271,9 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			blindEmoji = "💀"
 		}
 		msgStr := fmt.Sprintf("%s NOW ENTERING: %s (Ante %d) | Target: %d points", blindEmoji, event.Blind, event.Ante, event.Target)
+		if event.Blind == game.BossBlind && event.Boss != nil {
+			msgStr += fmt.Sprintf(" | Boss: %s - %s", event.Boss.Name, event.Boss.Effect)
+		}
 		m.setStatusMessage(msgStr)
 		m.logEvent(msgStr)
 		return m, nil

--- a/tests/boss_test.go
+++ b/tests/boss_test.go
@@ -1,0 +1,23 @@
+package game_test
+
+import (
+	"testing"
+
+	game "balatno/internal/game"
+)
+
+func TestGetBossForAnte(t *testing.T) {
+	if err := game.LoadBossConfigs(); err != nil {
+		t.Fatalf("LoadBossConfigs failed: %v", err)
+	}
+
+	boss := game.GetBossForAnte(1)
+	if boss.Final {
+		t.Errorf("expected non-final boss for ante 1, got final boss %s", boss.Name)
+	}
+
+	finalBoss := game.GetBossForAnte(8)
+	if !finalBoss.Final {
+		t.Errorf("expected final boss for ante 8, got non-final boss %s", finalBoss.Name)
+	}
+}


### PR DESCRIPTION
## Summary
- Parse bosses from `bosses.yaml` and expose selection logic that picks final bosses on antes divisible by eight
- Load bosses into game state, apply their effects during Boss Blinds, and surface boss details when entering Boss Blinds
- Document boss configuration format and provide tests for boss selection and effects

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b55c3a560832cb176a218c66cbdd2