### PR TITLE
Add composite joker defaults

### DIFF
--- a/docs/JOKER_CONFIG.md
+++ b/docs/JOKER_CONFIG.md
@@ -17,6 +17,8 @@ jokers:
         effect_magnitude: 30    # Strength of effect
         hand_matching_rule: "ContainsPair"  # When to trigger based on hand type
         card_matching_rule: "IsAce"         # (Optional) bonus per matching card
+
+`hand_matching_rule` and `card_matching_rule` default to `"None"` when omitted.
 ```
 
 ## 🎭 Effect Types

--- a/internal/game/jokers.go
+++ b/internal/game/jokers.go
@@ -210,10 +210,14 @@ func createJokerFromConfig(config JokerConfig) Joker {
 			if cardRule == "" {
 				cardRule = CardNone
 			}
+			handRule := e.HandMatchingRule
+			if handRule == "" {
+				handRule = None
+			}
 			effects = append(effects, JokerEffectConfig{
 				Effect:           e.Effect,
 				EffectMagnitude:  e.EffectMagnitude,
-				HandMatchingRule: e.HandMatchingRule,
+				HandMatchingRule: handRule,
 				CardMatchingRule: cardRule,
 			})
 		}
@@ -222,10 +226,14 @@ func createJokerFromConfig(config JokerConfig) Joker {
 		if cardRule == "" {
 			cardRule = CardNone
 		}
+		handRule := config.HandMatchingRule
+		if handRule == "" {
+			handRule = None
+		}
 		effects = append(effects, JokerEffectConfig{
 			Effect:           config.Effect,
 			EffectMagnitude:  config.EffectMagnitude,
-			HandMatchingRule: config.HandMatchingRule,
+			HandMatchingRule: handRule,
 			CardMatchingRule: cardRule,
 		})
 	}

--- a/internal/game/jokers_test.go
+++ b/internal/game/jokers_test.go
@@ -92,6 +92,27 @@ func TestCompositeJoker(t *testing.T) {
 	}
 }
 
+// TestCompositeMoneyAndChips verifies composite jokers with both money and chip effects.
+func TestCompositeMoneyAndChips(t *testing.T) {
+	cfg := JokerConfig{
+		Name: "Money Chips",
+		Effects: []JokerEffectConfig{
+			{Effect: AddMoney, EffectMagnitude: 3},
+			{Effect: AddChips, EffectMagnitude: 10, HandMatchingRule: ContainsPair},
+		},
+	}
+	joker := createJokerFromConfig(cfg)
+
+	if reward := CalculateJokerRewards([]Joker{joker}); reward != 3 {
+		t.Fatalf("expected money reward 3, got %d", reward)
+	}
+
+	chips, mult, factor := CalculateJokerHandBonus([]Joker{joker}, "Pair", []Card{})
+	if chips != 10 || mult != 0 || factor != 1 {
+		t.Fatalf("expected chips=10 mult=0 factor=1, got chips=%d mult=%d factor=%d", chips, mult, factor)
+	}
+}
+
 // TestMultiplyMult verifies jokers that multiply the multiplier.
 func TestMultiplyMult(t *testing.T) {
 	cfg := JokerConfig{Name: "Doubler", Effects: []JokerEffectConfig{{Effect: MultiplyMult, EffectMagnitude: 2, HandMatchingRule: ContainsPair}}}

--- a/internal/ui/tui_jokers.go
+++ b/internal/ui/tui_jokers.go
@@ -53,15 +53,15 @@ func (jm *JokerOrderMode) handleKeyPress(m *TUIModel, msg string) (tea.Model, te
 		}
 		return m, nil
 	case "s":
-		if jm.selected == nil {
+		if jm.selected == -1 {
 			m.setStatusMessage("Select a joker first")
 			return m, nil
 		}
-		idx := *jm.selected
+		idx := jm.selected
 		joker := m.gameState.Jokers[idx]
 		m.sendAction(game.PlayerActionSellJoker, []string{strconv.Itoa(idx + 1)})
 		m.gameState.Jokers = append(m.gameState.Jokers[:idx], m.gameState.Jokers[idx+1:]...)
-		jm.selected = nil
+		jm.selected = -1
 		m.setStatusMessage(fmt.Sprintf("Sold %s for $%d", joker.Name, joker.Price/2))
 		return m, nil
 	case "up", "k":


### PR DESCRIPTION
## Summary
- default missing hand matching rules to None so composite jokers can specify multiple effects without boilerplate
- verify composite jokers that add money and chips
- fix joker order selling logic using -1 sentinel

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0c50a67a0832cbc036214cbe97305